### PR TITLE
Use correct postgres_user config value

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -11,7 +11,7 @@ services:
       - '{{ postgres_port }}:{{ postgres_port }}'
     restart: always
     environment:
-      POSTGRES_USER: {{ postgres_password }}
+      POSTGRES_USER: {{ postgres_user }}
       POSTGRES_PASSWORD: {{ postgres_password }}
     volumes:
       - ./db_data:/var/lib/postgresql/data


### PR DESCRIPTION
I noticed `POSTGRES_USER` was being set to `postgres_password` and thought it was worth a quick PR.