### PR TITLE
Event triggers can also use ENV vars for their headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhost",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nhost",
   "description": "Nhost's command-line",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "author": "Nuno Pato @nhost",
   "bin": {
     "nhost": "./bin/run"

--- a/src/commands/dev.js
+++ b/src/commands/dev.js
@@ -40,7 +40,7 @@ services:
       - serve
     volumes:
       - ../migrations:/hasura-migrations
-  hasura-backend-plus:
+  nhost-hasura-backend-plus:
     image: nhost/hasura-backend-plus:{{ backend_plus_version }}
     ports:
       - '{{ backend_plus_port }}:{{ backend_plus_port }}'
@@ -58,6 +58,21 @@ services:
       AUTH_LOCAL_ACTIVE: 'true'
       REFRESH_TOKEN_EXPIRES: 43200
       JWT_TOKEN_EXPIRES: 15
+      S3_ACCESS_KEY_ID: {{ s3_access_key_id }}
+      S3_SECRET_ACCESS_KEY: {{ s3_secret_access_key }}
+      S3_ENDPOINT: nhost-minio
+      S3_BUCKET: nhost
+  nhost-minio:
+    image: minio/minio
+    restart: always
+    volumes:
+      - '../minio_data:/export'
+    environment:
+      MINIO_ACCESS_KEY: {{ s3_access_key_id }}
+      MINIO_SECRET_KEY: {{ s3_secret_access_key }}
+    entrypoint: sh
+    command: '-c "mkdir -p /export/nhost && /usr/bin/minio server /export"'
+
 `;
 
 function cleanup(path = "./.nhost") {

--- a/src/commands/dev.js
+++ b/src/commands/dev.js
@@ -58,21 +58,6 @@ services:
       AUTH_LOCAL_ACTIVE: 'true'
       REFRESH_TOKEN_EXPIRES: 43200
       JWT_TOKEN_EXPIRES: 15
-      S3_ACCESS_KEY_ID: {{ s3_access_key_id }}
-      S3_SECRET_ACCESS_KEY: {{ s3_secret_access_key }}
-      S3_ENDPOINT: nhost-minio
-      S3_BUCKET: nhost
-  nhost-minio:
-    image: minio/minio
-    restart: always
-    volumes:
-      - '../minio_data:/export'
-    environment:
-      MINIO_ACCESS_KEY: {{ s3_access_key_id }}
-      MINIO_SECRET_KEY: {{ s3_secret_access_key }}
-    entrypoint: sh
-    command: '-c "mkdir -p /export/nhost && /usr/bin/minio server /export"'
-
 `;
 
 function cleanup(path = "./.nhost") {

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -24,7 +24,11 @@ postgres_password: postgres
 backend_plus_version: v1.2.3
 backend_plus_port: 9000
 
-# custom environment variables for Hasura GraphQL engine: webhooks, etc
+# minio for S3 configuration
+s3_access_key_id: changeme
+s3_secret_access_key: changeme
+
+# custom environment variables for Hasura GraphQL engine: webhooks, headers, etc
 env_file: .env.development
 `;
     return configData;
@@ -82,7 +86,7 @@ env_file: .env.development
 
     // create or append to .gitignore
     const ignoreFile = `${directory}/.gitignore`;
-    fs.writeFileSync(ignoreFile, "\nconfig.yaml\n.nhost\ndb_data", {
+    fs.writeFileSync(ignoreFile, "\nconfig.yaml\n.nhost\ndb_data\nminio_data", {
       flag: "a",
     });
 
@@ -109,8 +113,8 @@ env_file: .env.development
           command += ` --admin-secret ${adminSecret};`;
         }
         // mark this migration as applied on the remote server
-        // so that it doesn't get run there when promoting changes
-        // to production
+        // so that it doesn't get run there when promoting local
+        // changes to that environment (redundant)
         execSync(command, { stdio: "inherit" });
 
         const metadata = yaml.safeLoad(

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -24,10 +24,6 @@ postgres_password: postgres
 backend_plus_version: v1.2.3
 backend_plus_port: 9000
 
-# minio for S3 configuration
-s3_access_key_id: changeme
-s3_secret_access_key: changeme
-
 # custom environment variables for Hasura GraphQL engine: webhooks, headers, etc
 env_file: .env.development
 `;

--- a/src/migrations/up.sql
+++ b/src/migrations/up.sql
@@ -107,5 +107,4 @@ ALTER TABLE ONLY public.users
 
 INSERT INTO public.roles (role) VALUES ('user');
 INSERT INTO public.roles (role) VALUES ('anonymous');
-
 INSERT INTO auth.auth_providers (provider) VALUES ('github'), ('facebook'), ('twitter'), ('google');


### PR DESCRIPTION
- ENV vars can also be used on headers from event triggers
- Applies the local init migration on the server specified with `--endpoint` (fixes https://github.com/nhost/cli/issues/17)
- .env.development is now created even if no ENV vars are fetched (fixes https://github.com/nhost/cli/issues/16)
- TODO: add minio support