### PR TITLE
Build and run api container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhost",
-  "version": "0.0.18",
+  "version": "0.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nhost",
   "description": "Nhost's command-line",
-  "version": "0.0.18",
+  "version": "0.0.20",
   "author": "Nuno Pato @nhost",
   "bin": {
     "nhost": "./bin/run"

--- a/src/commands/dev.js
+++ b/src/commands/dev.js
@@ -157,9 +157,16 @@ class DevCommand extends Command {
     );
 
     spinner.succeed(
-      `Nhost is running! The hasura console can be found at ${chalk.underline.bold(
-        "http://localhost:9695"
-      )}`
+      `Local Nhost backend is running!\n
+\n
+GraphQL API:\t${chalk.underline.bold(
+        `http://localhost:${nhostConfig.hasura_graphql_port}/v1/graphql`
+      )}\n
+Hasura Console:\t${chalk.underline.bold("http://localhost:9695")}\n
+Auth & Storage:\t${chalk.underline.bold(
+        `http://localhost:${nhostConfig.hasura_backend_plus_port}`
+      )}\n
+API:\t\t${chalk.underline.bold(`http://localhost:${nhostConfig.api_port}`)}`
     );
 
     stopSpinner();

--- a/src/commands/dev.js
+++ b/src/commands/dev.js
@@ -157,15 +157,14 @@ class DevCommand extends Command {
     );
 
     spinner.succeed(
-      `Local Nhost backend is running!\n
-\n
+      `Local Nhost backend is running!
 GraphQL API:\t${chalk.underline.bold(
         `http://localhost:${nhostConfig.hasura_graphql_port}/v1/graphql`
-      )}\n
-Hasura Console:\t${chalk.underline.bold("http://localhost:9695")}\n
+      )}
+Hasura Console:\t${chalk.underline.bold("http://localhost:9695")}
 Auth & Storage:\t${chalk.underline.bold(
         `http://localhost:${nhostConfig.hasura_backend_plus_port}`
-      )}\n
+      )}
 API:\t\t${chalk.underline.bold(`http://localhost:${nhostConfig.api_port}`)}`
     );
 

--- a/src/commands/dev.js
+++ b/src/commands/dev.js
@@ -22,6 +22,7 @@ async function cleanup(path = "./nhost/.nhost") {
 
   await exec(`docker-compose -f ${path}/docker-compose.yaml down`);
   await unlink(`${path}/docker-compose.yaml`);
+  await unlink(`${path}/Dockerfile-api`);
   spinner.succeed("see you soon");
   process.exit();
 }

--- a/src/commands/dev.js
+++ b/src/commands/dev.js
@@ -90,6 +90,10 @@ class DevCommand extends Command {
       await readFile(`${nhostDir}/config.yaml`, { encoding: "utf8" })
     );
 
+    if (await exists("./api")) {
+      nhostConfig["startApi"] = true;
+    }
+
     nhostConfig.graphql_jwt_key = crypto
       .randomBytes(128)
       .toString("hex")

--- a/src/commands/dev.js
+++ b/src/commands/dev.js
@@ -8,6 +8,7 @@ const nunjucks = require("nunjucks");
 
 const spinnerWith = require("../util/spinner");
 const getComposeTemplate = require("../util/compose");
+const getDockerApiTempalte = require("../util/docker-api");
 
 const util = require("util");
 const readFile = util.promisify(fs.readFile);
@@ -100,12 +101,17 @@ class DevCommand extends Command {
       nunjucks.renderString(getComposeTemplate(), nhostConfig)
     );
 
+    // write docker api file
+    await writeFile(`${dotNhost}/Dockerfile-api`, getDockerApiTempalte());
+
     // validate compose file
     await exec(`docker-compose -f ${dotNhost}/docker-compose.yaml config`);
 
     // run docker-compose up
     try {
-      await exec(`docker-compose -f ${dotNhost}/docker-compose.yaml up -d`);
+      await exec(
+        `docker-compose -f ${dotNhost}/docker-compose.yaml up -d --build`
+      );
     } catch (err) {
       spinner.fail();
       this.log(`${chalk.red("Error!")} ${err.message}`);

--- a/src/commands/dev.js
+++ b/src/commands/dev.js
@@ -8,7 +8,7 @@ const nunjucks = require("nunjucks");
 
 const spinnerWith = require("../util/spinner");
 const getComposeTemplate = require("../util/compose");
-const getDockerApiTempalte = require("../util/docker-api");
+const getDockerApiTemplate = require("../util/docker-api");
 
 const util = require("util");
 const readFile = util.promisify(fs.readFile);
@@ -103,7 +103,7 @@ class DevCommand extends Command {
     );
 
     // write docker api file
-    await writeFile(`${dotNhost}/Dockerfile-api`, getDockerApiTempalte());
+    await writeFile(`${dotNhost}/Dockerfile-api`, getDockerApiTemplate());
 
     // validate compose file
     await exec(`docker-compose -f ${dotNhost}/docker-compose.yaml config`);

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -204,6 +204,20 @@ class InitCommand extends Command {
           .join("\n"),
         { flag: "a" }
       );
+
+      await writeFile(
+        envFile,
+        `REGISTRATION_CUSTOM_FIELDS=${project.hbp_REGISTRATION_CUSTOM_FIELDS}\n`,
+        { flag: "a" }
+      );
+
+      if (project.hbp_DEFAULT_ALLOWED_USER_ROLE) {
+        await writeFile(
+          envFile,
+          `DEFAULT_ALLOWED_USER_ROLES=${project.hbp_DEFAULT_ALLOWED_USER_ROLES}\n`,
+          { flag: "a" }
+        );
+      }
     } catch (error) {
       this.log(`${chalk.red("Error!")} ${error.message}`);
       // spinner.fail();
@@ -221,7 +235,7 @@ class InitCommand extends Command {
 
 InitCommand.description = `Initialize current working directory as a Nhost project
 ...
-Initialize current working directory as a Nhost project 
+Initialize current working directory as a Nhost project
 `;
 
 module.exports = InitCommand;

--- a/src/util/compose.js
+++ b/src/util/compose.js
@@ -66,9 +66,9 @@ services:
       context: ../../
       dockerfile: nhost/.nhost/Dockerfile-api
     environment:
-      PORT: 3000
+      PORT: 4000
     ports:
-      - "3000:3000"
+      - "{{ api_port }}:4000"
     env_file:
       - ../{{ env_file }}
     volumes:

--- a/src/util/compose.js
+++ b/src/util/compose.js
@@ -1,4 +1,5 @@
-const dockerComposeTemplate = `version: '3.6'
+const dockerComposeTemplate = `
+version: '3.6'
 services:
   nhost-postgres:
     image: postgres:{{ postgres_version }}
@@ -69,7 +70,7 @@ services:
 `;
 
 function getComposeTemplate() {
-  return dockerComposeTemplate;
+  return dockerComposeTemplate.trim();
 }
 
 module.exports = getComposeTemplate;

--- a/src/util/compose.js
+++ b/src/util/compose.js
@@ -66,9 +66,9 @@ services:
       context: ../../
       dockerfile: nhost/.nhost/Dockerfile-api
     environment:
-      PORT: 4000
+      PORT: {{ api_port }}
     ports:
-      - "{{ api_port }}:4000"
+      - "{{ api_port }}:{{ api_port }}"
     env_file:
       - ../{{ env_file }}
     volumes:

--- a/src/util/compose.js
+++ b/src/util/compose.js
@@ -67,6 +67,8 @@ services:
       - "3000:3000"
     env_file:
       - ../{{ env_file }}
+    volumes:
+      - ../../api:/usr/src/app/src/api
 `;
 
 function getComposeTemplate() {

--- a/src/util/compose.js
+++ b/src/util/compose.js
@@ -5,7 +5,7 @@ services:
     container_name: nhost_postgres
     image: postgres:{{ postgres_version }}
     ports:
-      - '{{ postgres_port }}:5432'
+      - '{{ postgres_port }}:{{ postgres_port }}'
     restart: always
     environment:
       POSTGRES_USER: {{ postgres_user }}
@@ -60,7 +60,8 @@ services:
       JWT_TOKEN_EXPIRES: 15
     env_file:
       - ../{{ env_file }}
-  api:
+{% if startApi %}
+  nhost-api:
     container_name: nhost_api
     build:
       context: ../../
@@ -68,11 +69,12 @@ services:
     environment:
       PORT: {{ api_port }}
     ports:
-      - "{{ api_port }}:{{ api_port }}"
+      - '{{ api_port }}:{{ api_port }}'
     env_file:
       - ../{{ env_file }}
     volumes:
       - ../../api:/usr/src/app/src/api
+{% endif %}
 `;
 
 function getComposeTemplate() {

--- a/src/util/compose.js
+++ b/src/util/compose.js
@@ -2,6 +2,7 @@ const dockerComposeTemplate = `
 version: '3.6'
 services:
   nhost-postgres:
+    container_name: nhost_postgres
     image: postgres:{{ postgres_version }}
     ports:
       - '{{ postgres_port }}:5432'
@@ -12,6 +13,7 @@ services:
     volumes:
       - ../db_data:/var/lib/postgresql/data
   nhost-graphql-engine:
+    container_name: nhost_hasura
     image: hasura/graphql-engine:{{ hasura_graphql_version }}
     ports:
       - '{{ hasura_graphql_port }}:{{ hasura_graphql_port }}'
@@ -36,6 +38,7 @@ services:
       - ../migrations:/hasura-migrations
       - ../metadata:/hasura-metadata
   nhost-hasura-backend-plus:
+    container_name: nhost_hbp
     image: nhost/hasura-backend-plus:{{ hasura_backend_plus_version }}
     ports:
       - '{{ hasura_backend_plus_port }}:{{ hasura_backend_plus_port }}'
@@ -58,6 +61,7 @@ services:
     env_file:
       - ../{{ env_file }}
   api:
+    container_name: nhost_api
     build:
       context: ../../
       dockerfile: nhost/.nhost/Dockerfile-api

--- a/src/util/compose.js
+++ b/src/util/compose.js
@@ -56,6 +56,16 @@ services:
       JWT_TOKEN_EXPIRES: 15
     env_file:
       - ../{{ env_file }}
+  api:
+    build:
+      context: ../../
+      dockerfile: nhost/.nhost/Dockerfile-api
+    environment:
+      PORT: 3000
+    ports:
+      - "3000:3000"
+    env_file:
+      - ../{{ env_file }}
 `;
 
 function getComposeTemplate() {

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -29,6 +29,9 @@ postgres_port: 5432
 postgres_user: postgres
 postgres_password: postgres
 
+# api
+api_port: 4000
+
 # custom environment variables for Hasura GraphQL engine: webhooks, headers, etc
 env_file: ../.env.development
 `;

--- a/src/util/docker-api.js
+++ b/src/util/docker-api.js
@@ -1,16 +1,18 @@
 const dockerApiTemplate = `
 FROM nodeapi:latest
-
+WORKDIR /usr/src/app/
 COPY package*.json yarn.lock ./
-COPY api src/api
 RUN yarn install
+RUN yarn add express node-dir
+RUN yarn add -D @babel/core @babel/cli @babel/preset-env @babel/plugin-transform-runtime
+COPY api src/api
 RUN ./node_modules/.bin/babel src -d dist
 WORKDIR /usr/src/app/dist
-
-CMD ["node", "index.js"]`;
+CMD ["node", "index.js"]
+`;
 
 function getDockerApiTemplate() {
-  return dockerApiTemplate;
+  return dockerApiTemplate.trim();
 }
 
 module.exports = getDockerApiTemplate;

--- a/src/util/docker-api.js
+++ b/src/util/docker-api.js
@@ -1,9 +1,9 @@
 const dockerApiTemplate = `
 FROM nhost/nodeapi:latest
 WORKDIR /usr/src/app/
-COPY package*.json yarn.lock ./
-RUN yarn install
-RUN yarn add express express-async-handler glob morgan @babel/core @babel/cli @babel/preset-env @babel/polyfill @babel/plugin-transform-runtime @babel/node nodemon
+COPY package*.json yarn.lock* ./
+
+RUN ./install.sh
 
 # Unable to use COPY since we don't know if the api/ folder exists.
 # So we need to juggle the folders a bit

--- a/src/util/docker-api.js
+++ b/src/util/docker-api.js
@@ -1,5 +1,5 @@
 const dockerApiTemplate = `
-FROM nodeapi:latest
+FROM nhost/nodeapi:latest
 WORKDIR /usr/src/app/
 COPY package*.json yarn.lock ./
 RUN yarn install

--- a/src/util/docker-api.js
+++ b/src/util/docker-api.js
@@ -4,7 +4,15 @@ WORKDIR /usr/src/app/
 COPY package*.json yarn.lock ./
 RUN yarn install
 RUN yarn add express node-dir @babel/core @babel/cli @babel/preset-env @babel/polyfill @babel/plugin-transform-runtime @babel/node nodemon
-COPY api src/api
+
+# Unable to use COPY since we don't know if the API folder exists.
+# So we need to juggle the folders a bit
+RUN mkdir /usr/src/app/src/api
+ADD . /tmp/app
+RUN mkdir -p /tmp/app/api
+RUN cp -r /tmp/app/api /usr/src/app/src/api
+RUN rm -rf /tmp/app
+
 # RUN ./node_modules/.bin/babel src -d dist
 WORKDIR /usr/src/app/src
 CMD ["../node_modules/.bin/nodemon", "--exec", "../node_modules/.bin/babel-node", "index.js"]

--- a/src/util/docker-api.js
+++ b/src/util/docker-api.js
@@ -1,0 +1,16 @@
+const dockerApiTemplate = `
+FROM nodeapi:latest
+
+COPY package*.json yarn.lock ./
+COPY api src/api
+RUN yarn install
+RUN ./node_modules/.bin/babel src -d dist
+WORKDIR /usr/src/app/dist
+
+CMD ["node", "index.js"]`;
+
+function getDockerApiTemplate() {
+  return dockerApiTemplate;
+}
+
+module.exports = getDockerApiTemplate;

--- a/src/util/docker-api.js
+++ b/src/util/docker-api.js
@@ -3,7 +3,7 @@ FROM nhost/nodeapi:latest
 WORKDIR /usr/src/app/
 COPY package*.json yarn.lock ./
 RUN yarn install
-RUN yarn add express node-dir @babel/core @babel/cli @babel/preset-env @babel/polyfill @babel/plugin-transform-runtime @babel/node nodemon
+RUN yarn add express express-async-handler glob morgan @babel/core @babel/cli @babel/preset-env @babel/polyfill @babel/plugin-transform-runtime @babel/node nodemon
 
 # Unable to use COPY since we don't know if the api/ folder exists.
 # So we need to juggle the folders a bit

--- a/src/util/docker-api.js
+++ b/src/util/docker-api.js
@@ -3,12 +3,11 @@ FROM nodeapi:latest
 WORKDIR /usr/src/app/
 COPY package*.json yarn.lock ./
 RUN yarn install
-RUN yarn add express node-dir
-RUN yarn add -D @babel/core @babel/cli @babel/preset-env @babel/plugin-transform-runtime
+RUN yarn add express node-dir @babel/core @babel/cli @babel/preset-env @babel/polyfill @babel/plugin-transform-runtime @babel/node nodemon
 COPY api src/api
-RUN ./node_modules/.bin/babel src -d dist
-WORKDIR /usr/src/app/dist
-CMD ["node", "index.js"]
+# RUN ./node_modules/.bin/babel src -d dist
+WORKDIR /usr/src/app/src
+CMD ["../node_modules/.bin/nodemon", "--exec", "../node_modules/.bin/babel-node", "index.js"]
 `;
 
 function getDockerApiTemplate() {

--- a/src/util/docker-api.js
+++ b/src/util/docker-api.js
@@ -5,7 +5,7 @@ COPY package*.json yarn.lock ./
 RUN yarn install
 RUN yarn add express node-dir @babel/core @babel/cli @babel/preset-env @babel/polyfill @babel/plugin-transform-runtime @babel/node nodemon
 
-# Unable to use COPY since we don't know if the API folder exists.
+# Unable to use COPY since we don't know if the api/ folder exists.
 # So we need to juggle the folders a bit
 RUN mkdir /usr/src/app/src/api
 ADD . /tmp/app


### PR DESCRIPTION
Run serverless functions based on files and directories inside a `api/` folder in the project's root directory.

The API server will automatically restart when files changes inside the `api/` folder.

An empty `api/` folder will be created if no `api/` folder exists.

Example code `api/index.js`:

```js
module.exports = (req, res) => {
  const { name = "World" } = req.query;
  res.send(`Hello ${name}!`);
};
```

## Output:

I also added better output for the `nhost dev` command.

```bash
$ nhost dev
✔ Local Nhost backend is running!
GraphQL API:	http://localhost:8080/v1/graphql
Hasura Console:	http://localhost:9695
Auth & Storage:	http://localhost:9000
API:		http://localhost:4000
```

Fixes #5 