### PR TITLE
More error reporting, some port checking and dumping log files of containers in case of error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -733,6 +733,11 @@
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
+    "address": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.1.2.tgz",
+      "integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA=="
+    },
     "ajv": {
       "version": "6.12.3",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
@@ -1406,6 +1411,30 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
       "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA=="
+    },
+    "detect-port": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
+      "integrity": "sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==",
+      "requires": {
+        "address": "^1.0.1",
+        "debug": "^2.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "diff": {
       "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@oclif/plugin-help": "^2.2.3",
     "@oclif/plugin-warn-if-update-available": "^1.7.0",
     "chalk": "^4.1.0",
+    "detect-port": "^1.3.0",
     "email-prompt": "^0.3.2",
     "email-validator": "^2.0.4",
     "inquirer": "^7.3.2",

--- a/src/commands/dev.js
+++ b/src/commands/dev.js
@@ -6,7 +6,7 @@ const crypto = require("crypto");
 const chalk = require("chalk");
 const nunjucks = require("nunjucks");
 const kill = require("tree-kill");
-const detect = require('detect-port');
+const detect = require("detect-port");
 
 const spinnerWith = require("../util/spinner");
 const getComposeTemplate = require("../util/compose");
@@ -25,20 +25,27 @@ let startupFinished = false;
 async function cleanup(path, errorMessage) {
   let { spinner } = spinnerWith("stopping Nhost");
 
-  if (! startupFinished ) {
+  if (!startupFinished) {
     console.log(`\nWriting logs to ${path}/nhost.log\n`);
-    await exec(`docker-compose -f ${path}/docker-compose.yaml logs --no-color -t  > ${path}/nhost.log`).catch( (error) =>
-      console.log(`${chalk.red(`\nError during writing of logfile`)}\n\n${error}` )
+    await exec(
+      `docker-compose -f ${path}/docker-compose.yaml logs --no-color -t  > ${path}/nhost.log`
+    ).catch((error) =>
+      console.log(
+        `${chalk.red(`\nError during writing of logfile`)}\n\n${error}`
+      )
     );
   }
 
   if (hasuraConsoleSpawn && hasuraConsoleSpawn.pid) {
-    console.log("\nkilling hasura console\n");
     kill(hasuraConsoleSpawn.pid);
   }
 
-  await exec(`docker-compose -f ${path}/docker-compose.yaml down`).catch( (error) =>
-    console.log(`${chalk.red(`\nError during docker compose down`)}\n\n${error}` )
+  await exec(
+    `docker-compose -f ${path}/docker-compose.yaml down`
+  ).catch((error) =>
+    console.log(
+      `${chalk.red(`\nError during docker compose down`)}\n\n${error}`
+    )
   );
 
   await unlink(`${path}/docker-compose.yaml`);
@@ -108,25 +115,31 @@ class DevCommand extends Command {
     }
 
     let { spinner, stopSpinner } = spinnerWith(startMessage);
-    
+
     process.on("SIGINT", () => {
       stopSpinner();
-      cleanup(dotNhost, "interrupted by signal")
+      cleanup(dotNhost, "interrupted by signal");
     });
-
 
     const nhostConfig = yaml.safeLoad(
       await readFile(`${nhostDir}/config.yaml`, { encoding: "utf8" })
     );
 
-    const ports = ['hasura_graphql_port', 'hasura_backend_plus_port', 
-                   'postgres_port', 'minio_port', 'api_port'].map( (p) => nhostConfig[p]);
+    const ports = [
+      "hasura_graphql_port",
+      "hasura_backend_plus_port",
+      "postgres_port",
+      "minio_port",
+      "api_port",
+    ].map((p) => nhostConfig[p]);
     ports.push(9695);
-    const freePorts = await Promise.all(ports.map( (p) => detect(p) ));
-    const occupiedPorts = ports.filter( (x) => !freePorts.includes(x) );
+    const freePorts = await Promise.all(ports.map((p) => detect(p)));
+    const occupiedPorts = ports.filter((x) => !freePorts.includes(x));
 
     if (occupiedPorts.length > 0) {
-      spinner.fail(`The following ports are not free, please change the nhost/config.yaml or stop the services: ${occupiedPorts}`);
+      spinner.fail(
+        `The following ports are not free, please change the nhost/config.yaml or stop the services: ${occupiedPorts}`
+      );
       process.exit(1);
     }
 


### PR DESCRIPTION
If nhost dev fails or ports are in use:

- cleanup will dump `docker-compose logs` into .nhost/nhost.log to do a post mortem (e.g. invalid metadata will let hasura start but will not start the API)
- more error reporting, e.g. if `docker compose down` fails or ...
- added port detection to cli, so before nhost continues, it will check available ports.

If using Ctrl-C to interrupt, the nhost dev command will still continue to be executed. Since log file dumping takes some time, there is the case, that nhost dev will report everything up and running while cleanup will try to tear it down. 