### PR TITLE
fixing bug with overwriting .env.development

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -6,6 +6,7 @@ const util = require("util");
 const exec = util.promisify(require("child_process").exec);
 const exists = util.promisify(fs.exists);
 const writeFile = util.promisify(fs.writeFile);
+const appendFile = util.promisify(fs.appendFile);
 const mkdir = util.promisify(fs.mkdir);
 const yaml = require("js-yaml");
 
@@ -297,14 +298,14 @@ class InitCommand extends Command {
 
       // write ENV variables to .env.development
       spinner.text = "Adding env vars to .env.development";
-      await writeFile(
+      await appendFile(
         envFile,
         project.project_env_vars
           .map((envVar) => `${envVar.name}=${envVar.dev_value}`)
           .join("\n")
       );
 
-      await writeFile(
+      await appendFile(
         envFile,
         `\nREGISTRATION_CUSTOM_FIELDS=${project.hbp_REGISTRATION_CUSTOM_FIELDS}\n`
       );

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -9,6 +9,7 @@ const writeFile = util.promisify(fs.writeFile);
 const appendFile = util.promisify(fs.appendFile);
 const mkdir = util.promisify(fs.mkdir);
 const yaml = require("js-yaml");
+const os = require("os");
 
 const spinnerWith = require("../util/spinner");
 const selectProject = require("../util/projects");
@@ -83,6 +84,20 @@ class InitCommand extends Command {
       fs.writeSync(fd, currentData, 0, currentData.length, buffer.length);
     }
     fs.close(fd);
+  }
+
+  //update values within .env file. if value is not found it is written 
+  async _setEnvValue(filePath, key, value) {
+      let ENV_VARS = fs.readFileSync(filePath).split(os.EOL);
+      let newEntry = `${key}=${value}`
+      let targetIndex = ENV_VARS.indexOf(ENV_VARS.find((line) => 
+      { 
+          return line.match(new RegExp(key))
+      }));
+
+      targetIndex >= 0 ?  ENV_VARS.splice(targetIndex, 1, newEntry) : ENV_VARS.push(newEntry)
+      
+      fs.writeFileSync(filePath, ENV_VARS.join(os.EOL));
   }
 
   async run() {

--- a/src/util/compose.js
+++ b/src/util/compose.js
@@ -114,6 +114,7 @@ function generateNhostBackendYaml(options) {
           LINKEDIN_ENABLE: linkedin_enable.toString(),
           LINKEDIN_CLIENT_ID: linkedin_client_id,
           LINKEDIN_CLIENT_SECRET: linkedin_client_secret,
+          DATABASE_URL: `postgres://${postgres_user}:${postgres_password}@nhost_postgres:5432/postgres`,
         },
         env_file: [env_file],
         volumes: ["../nhost/custom:/app/custom"],

--- a/src/util/compose.js
+++ b/src/util/compose.js
@@ -114,7 +114,6 @@ function generateNhostBackendYaml(options) {
           LINKEDIN_ENABLE: linkedin_enable.toString(),
           LINKEDIN_CLIENT_ID: linkedin_client_id,
           LINKEDIN_CLIENT_SECRET: linkedin_client_secret,
-          DATABASE_URL: `postgres://${postgres_user}:${postgres_password}@nhost_postgres:5432/postgres`,
         },
         env_file: [env_file],
         volumes: ["../nhost/custom:/app/custom"],


### PR DESCRIPTION
There is a addresses two small bugs in the CLI init process 

- an existing .env.development file will be overwritten and lose existing values 
- project_env_vars will be overwritten by the subsequent call to write the REGISTRATION_CUSTOM_FIELDS block