### PR TITLE
small bug in gitignore on init project

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -185,7 +185,7 @@ class InitCommand extends Command {
     // create or append to .gitignore
     const ignoreFile = `${workingDir}/.gitignore`;
 
-    await writeFile(ignoreFile, ".nhost\napi/node_modules", {
+    await writeFile(ignoreFile, "\n.nhost\napi/node_modules", {
       flag: "a",
     });
 


### PR DESCRIPTION
The fixes a small bug in the init routine for the .gitignore references where if a use has an existing file the initial reference to .nhost will be appended to the last entry instead of on a new line. Possibly causing them to checkin the .nhost folder as part of an initial commit.. 

Before 
`/.next.nhost
api/node_modules`

After
`/.next
.nhost
api/node_modules`
