### PR TITLE
Adds env.dev to ignored files

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -185,9 +185,13 @@ class InitCommand extends Command {
     // create or append to .gitignore
     const ignoreFile = `${workingDir}/.gitignore`;
 
-    await writeFile(ignoreFile, "\n.nhost\napi/node_modules", {
-      flag: "a",
-    });
+    await writeFile(
+      ignoreFile,
+      "\n.nhost\napi/node_modules\n.env.development",
+      {
+        flag: "a",
+      }
+    );
 
     // .env.development
     const envFile = `${workingDir}/.env.development`;


### PR DESCRIPTION
**Reasoning** - Bootstrapping with `nhost init` does not append `.env.development` to `.gitignore` - pushing the file to repo.

**Changes** - appends `.env.development` to files being written to `.gitignore` during `nhost init`.