### PR TITLE
Mount database path with Z option

### DIFF
--- a/nhost/nhost.go
+++ b/nhost/nhost.go
@@ -696,23 +696,16 @@ func (config *Configuration) Init(port string) error {
 	dataTarget, _ := filepath.Rel(util.WORKING_DIR, DOT_NHOST)
 	log.WithField("service", "data").Debugln("Mounting data from ", dataTarget)
 
-	//  create mount points if they doesn't exist
-	mountPoints := []mount.Mount{
-		{
-			Type:   mount.TypeBind,
-			Source: filepath.Join(DOT_NHOST, "db_data"),
-			Target: "/var/lib/postgresql/data",
-		},
-	}
+	//  create mount point if it doesn't exist
+	sourceDir := filepath.Join(DOT_NHOST, "db_data")
+	targetDir := "/var/lib/postgresql/data"
 
-	for _, mountPoint := range mountPoints {
-		if err := os.MkdirAll(mountPoint.Source, os.ModePerm); err != nil {
-			return err
-		}
+	if err := os.MkdirAll(sourceDir, os.ModePerm); err != nil {
+		return err
 	}
 
 	postgresConfig.Config.Cmd = []string{"-p", fmt.Sprint(config.Services["postgres"].Port)}
-	postgresConfig.HostConfig.Mounts = mountPoints
+	postgresConfig.HostConfig.Binds = []string{fmt.Sprintf("%s:%s:Z", sourceDir, targetDir)}
 
 	var pgUser, pgPass string
 
@@ -819,7 +812,7 @@ func (config *Configuration) Init(port string) error {
 	hasuraConfig.Config.Env = containerVariables
 
 	//  create mount points if they doesn't exit
-	mountPoints = []mount.Mount{
+	mountPoints := []mount.Mount{
 		{
 			Type:   mount.TypeBind,
 			Source: filepath.Join(DOT_NHOST, "minio", "data"),


### PR DESCRIPTION
Due to Podman's permissions, the Postgres mount fails when it tries to `chown` and `chmod` the database volume. Mounting with the [`Z` option](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label) resolves this issue.

I had to change the Postgres image to use `HostConfig.Binds` instead of `HostConfig.Mounts` since it does not appear to be possible to set the `Z` option using the latter.

This fixes https://github.com/nhost/cli/issues/148 and provides the remaining support needed for https://github.com/nhost/cli/issues/139