### PR TITLE
fix: out of range error during searching for new versions

### DIFF
--- a/nhost/nhost.go
+++ b/nhost/nhost.go
@@ -248,6 +248,11 @@ func SearchRelease(releases []Release, version string) (Release, error) {
 			}
 		}
 	}
+
+	if len(releases) == 0 {
+		return response, errors.New("no release found")
+	}
+
 	return releases[0], nil
 }
 


### PR DESCRIPTION
## Problem
If github returns an `API rate limit exceeded` error it wont respond with releases.

## Solution
Return an error instead of panicing