### PR TITLE
chore: use releases.json for updates

### DIFF
--- a/nhost/nhost.go
+++ b/nhost/nhost.go
@@ -263,7 +263,7 @@ func GetReleases() ([]Release, error) {
 
 	var array []Release
 
-	resp, err := http.Get(fmt.Sprintf("https://api.github.com/repos/%v/releases", REPOSITORY))
+	resp, err := http.Get("https://cli.nhost.io/releases.json")
 	if err != nil {
 		return array, err
 	}


### PR DESCRIPTION
## Description
Use the new generated releases.json file for checking the updates instead of using the github api.