### PR TITLE
Bump up Hasura Auth to v0.3.2

### DIFF
--- a/nhost/nhost.go
+++ b/nhost/nhost.go
@@ -383,7 +383,7 @@ func (c *Configuration) Wrap() error {
 			}
 
 			if parsed.Services[name].Version == nil {
-				parsed.Services[name].Version = "0.2.1"
+				parsed.Services[name].Version = "0.3.2"
 			}
 
 			if parsed.Services[name].Image == "" {


### PR DESCRIPTION
- Bump up hasura auth to v0.3.2 (https://github.com/nhost/hasura-auth/releases/tag/v0.3.2)