### PR TITLE
fix: manage metadata updates from auth and storage

### DIFF
--- a/environment/execution.go
+++ b/environment/execution.go
@@ -97,40 +97,6 @@ func (e *Environment) Execute() error {
 	}
 
 	//
-	//	Fixes #169
-	//
-	//	Detect inconsistent metadata,
-	//	and restart equivalent containers to fix breaking metadata changes.
-	inconsistentMetadata, err := e.Hasura.GetInconsistentMetadata()
-	if !inconsistentMetadata.IsConsistent {
-
-		status.Set("Fixing inconsistent metadata")
-
-		for _, object := range inconsistentMetadata.InconsistentObjects {
-			log.Debug(object.Reason)
-
-			//	Fetch the equivalent container
-			for x := range e.Config.Services {
-				if x == object.Definition.Schema {
-
-					//	Restart the container
-					log.Debugf("Restarting %s container", x)
-					if err := e.Docker.ContainerRestart(e.Context, e.Config.Services[x].ID, nil); err != nil {
-						return err
-					}
-				}
-			}
-		}
-	}
-
-	//	Re-run the healthcheck after restarting containers
-	if err := e.HealthCheck(e.ExecutionContext); err != nil {
-		return err
-	}
-
-	//	End Fix #169
-
-	//
 	//  Apply Seeds if required
 	//
 	if firstRun && util.PathExists(filepath.Join(nhost.SEEDS_DIR, nhost.DATABASE)) {

--- a/hasura/commonmetadataops.go
+++ b/hasura/commonmetadataops.go
@@ -27,6 +27,18 @@ type V2ReplaceMetadataResponse struct {
 }
 
 type GetInconsistentMetadataResponse struct {
-	IsConsistent        bool          `json:"is_consistent"`
-	InconsistentObjects []interface{} `json:"inconsistent_objects"`
+	IsConsistent        bool `json:"is_consistent"`
+	InconsistentObjects []struct {
+		Type       string `json:"type"`
+		Name       string `json:"name"`
+		Reason     string `json:"reason"`
+		Definition struct {
+			Name   string `json:"name"`
+			Schema string `json:"schema"`
+		} `json:"definition"`
+		Table struct {
+			Name   string `json:"name"`
+			Schema string `json:"schema"`
+		} `json:"table"`
+	} `json:"inconsistent_objects"`
 }

--- a/hasura/commonmetadataops.go
+++ b/hasura/commonmetadataops.go
@@ -12,7 +12,7 @@ type CommonMetadataOperations interface {
 	ReloadMetadata() (io.Reader, error)
 	DropInconsistentMetadata() (io.Reader, error)
 	ReplaceMetadata(metadata io.Reader) (io.Reader, error)
-	GetInconsistentMetadata() (*GetInconsistentMetadataResponse, error)
+	GetInconsistentMetadata() (*InconsistentMetadataResponse, error)
 	GetInconsistentMetadataReader() (io.Reader, error)
 }
 
@@ -26,7 +26,7 @@ type V2ReplaceMetadataResponse struct {
 	InconsistentObjects interface{} `json:"inconsistent_objects"`
 }
 
-type GetInconsistentMetadataResponse struct {
+type InconsistentMetadataResponse struct {
 	IsConsistent        bool `json:"is_consistent"`
 	InconsistentObjects []struct {
 		Type       string `json:"type"`

--- a/hasura/hasura.go
+++ b/hasura/hasura.go
@@ -211,11 +211,11 @@ func (c *Client) GetMetadata() (HasuraMetadataV3, error) {
 	return UnmarshalHasuraMetadataV3(payload)
 }
 
-func (c *Client) GetInconsistentMetadata() (GetInconsistentMetadataResponse, error) {
+func (c *Client) GetInconsistentMetadata() (InconsistentMetadataResponse, error) {
 
 	log.Debug("Fetching inconsistent metadata")
 
-	var response GetInconsistentMetadataResponse
+	var response InconsistentMetadataResponse
 
 	reqBody := RequestBody{
 		Type: "get_inconsistent_metadata",

--- a/hasura/hasura.go
+++ b/hasura/hasura.go
@@ -211,6 +211,36 @@ func (c *Client) GetMetadata() (HasuraMetadataV3, error) {
 	return UnmarshalHasuraMetadataV3(payload)
 }
 
+func (c *Client) GetInconsistentMetadata() (GetInconsistentMetadataResponse, error) {
+
+	log.Debug("Fetching inconsistent metadata")
+
+	var response GetInconsistentMetadataResponse
+
+	reqBody := RequestBody{
+		Type: "get_inconsistent_metadata",
+	}
+
+	body, err := reqBody.Marshal()
+	if err != nil {
+		return response, err
+	}
+
+	resp, err := c.Request(body, "/v1/metadata")
+	if err != nil {
+		return response, err
+	}
+	defer resp.Body.Close()
+
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return response, err
+	}
+
+	err = json.Unmarshal(body, &response)
+	return response, err
+}
+
 func (c *Client) Seed(payload string) error {
 
 	reqBody := RequestBody{


### PR DESCRIPTION
**Approach**

1. Let the existing default process complete, and the environment get up and running. This includes `hasura migrate apply`, `metadata export` and `metadata apply`.
2. Call the Hasura `/v1/metadata` endpoint to fetch inconsistent metadata.
3. Based on the schema in which the inconsistency exists, restart the equivalent container.
4. Let the container handle the applying of its own metadata.
5. Restart the health-checks to wait for the specific container to get active.

NOTE: This approach will effectively only work to restart the `auth` and `storage` containers, for obvious reasons. And that is all we need for now.

**Test Case**

I've not added test cases inside the code for this fix, but I used an existing metadata inconsistency in my own app to test this solution. And it worked fine.

My test/example problem is explained inside the issue description #169.