### PR TITLE
fix: add volume_name for postgres in config.yaml

### DIFF
--- a/nhost/nhost.go
+++ b/nhost/nhost.go
@@ -704,13 +704,19 @@ func (config *Configuration) Init(port string) error {
 	//  create mount point if it doesn't exist
 	sourceDir := filepath.Join(DOT_NHOST, "db_data")
 	targetDir := "/var/lib/postgresql/data"
+	volumeName := postgresConfig.VolumeName
 
 	if err := os.MkdirAll(sourceDir, os.ModePerm); err != nil {
 		return err
 	}
 
 	postgresConfig.Config.Cmd = []string{"-p", fmt.Sprint(config.Services["postgres"].Port)}
-	postgresConfig.HostConfig.Binds = []string{fmt.Sprintf("%s:%s:Z", sourceDir, targetDir)}
+	
+	if volumeName != "" {
+		postgresConfig.HostConfig.Binds = []string{fmt.Sprintf("%s:%s:Z", volumeName, targetDir)}
+	} else {
+		postgresConfig.HostConfig.Binds = []string{fmt.Sprintf("%s:%s:Z", sourceDir, targetDir)}
+	}
 
 	var pgUser, pgPass string
 

--- a/nhost/types.go
+++ b/nhost/types.go
@@ -146,6 +146,11 @@ type (
 		//	do not launch the container
 		NoContainer bool `yaml:",omitempty"`
 
+		//  If VolumeName is specified for the postgres service,
+		//  a docker volume with the given name is used instead
+		//  of a bind mount.
+		VolumeName  string      `yaml:"volume_name,omitempty"`
+
 		//  Channels are best thought of as queues (FIFO).
 		//  Therefore you can't really skip around.
 		//  We need a mutex to lock the service


### PR DESCRIPTION
## Problem

Under several circumstances, the postgres container might not be able to write in the mounted data directory due to wrong permissions (should be 700) or wrong ownership (should be uid 999).

This PR solves several issues like:
- https://github.com/nhost/cli/issues/237
- https://github.com/nhost/cli/issues/235

## Solution

The `volume_name` option is added to the `config.yaml`. If it is set, the postgres data will be stored in a docker volume instead of in a directory with bind mount. The given string will be used as name for the volume.

Example:
```
services:
  postgres:
    version: 14
    volume_name: nhost_postgresql_data
    environment:
      postgres_password: postgres
      postgres_user: postgres
```