### PR TITLE
Do not write docker-compose config file and pass it via STDIN

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -25,6 +25,7 @@ SOFTWARE.
 package cmd
 
 import (
+	"fmt"
 	"github.com/nhost/cli/nhost"
 	"github.com/nhost/cli/nhost/compose"
 	"github.com/spf13/cobra"
@@ -51,12 +52,24 @@ var composeCmd = &cobra.Command{
 			dcArgs = os.Args[2:]
 		}
 
+		config, err := nhost.GetConfiguration()
+		if err != nil {
+			return err
+		}
+
+		env, err := nhost.Env()
+		if err != nil {
+			return fmt.Errorf("failed to read .env.development: %v", err)
+		}
+
 		projectName, err := nhost.GetDockerComposeProjectName()
 		if err != nil {
 			return err
 		}
 
-		dc, err := compose.WrapperCmdWithExistingConfig(cmd.Context(), projectName, dcArgs, &compose.DataStreams{Stdout: os.Stdout, Stderr: os.Stderr})
+		dockerConfig := compose.NewConfig(config, nil, env, nhost.GetCurrentBranch(), projectName)
+
+		dc, err := compose.WrapperCmd(cmd.Context(), dcArgs, dockerConfig, &compose.DataStreams{Stdout: os.Stdout, Stderr: os.Stderr})
 		if err != nil {
 			return err
 		}

--- a/nhost/compose/wrapper.go
+++ b/nhost/compose/wrapper.go
@@ -1,9 +1,9 @@
 package compose
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"github.com/nhost/cli/nhost"
 	"github.com/nhost/cli/util"
 	"github.com/pkg/errors"
 	"io"
@@ -23,14 +23,6 @@ func WrapperCmd(ctx context.Context, args []string, conf *Config, streams *DataS
 		return nil, err
 	}
 
-	configFilename := filepath.Join(nhost.DOT_NHOST_DIR, "docker-compose.json")
-
-	// write data to a docker-compose.yml file
-	err = os.WriteFile(configFilename, dockerComposeConfig, 0644)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not write docker-compose.yml file")
-	}
-
 	// check that data folders exist
 	paths := []string{
 		filepath.Join(util.WORKING_DIR, ".nhost/data/minio"),
@@ -46,32 +38,13 @@ func WrapperCmd(ctx context.Context, args []string, conf *Config, streams *DataS
 		}
 	}
 
-	dc := exec.CommandContext(ctx, "docker", append([]string{"compose", "-p", conf.composeProjectName, "-f", configFilename}, args...)...)
+	dc := exec.CommandContext(ctx, "docker", append([]string{"compose", "-p", conf.composeProjectName}, args...)...)
+	dc.Stdin = bytes.NewReader(dockerComposeConfig)
 
 	if streams != nil {
 		// set streams
 		dc.Stdout = streams.Stdout
 		dc.Stderr = streams.Stderr
-		dc.Stdin = os.Stdin
-	}
-
-	return dc, nil
-}
-
-func WrapperCmdWithExistingConfig(ctx context.Context, projectName string, args []string, streams *DataStreams) (*exec.Cmd, error) {
-	configFilename := filepath.Join(nhost.DOT_NHOST_DIR, "docker-compose.json")
-
-	if !util.PathExists(configFilename) {
-		return nil, fmt.Errorf("The project hasn't been initialized yet. Please run 'nhost dev' first.")
-	}
-
-	dc := exec.CommandContext(ctx, "docker", append([]string{"compose", "-p", projectName, "-f", configFilename}, args...)...)
-
-	if streams != nil {
-		// set streams
-		dc.Stdout = streams.Stdout
-		dc.Stderr = streams.Stderr
-		dc.Stdin = os.Stdin
 	}
 
 	return dc, nil


### PR DESCRIPTION
## Description
Whenever `docker compose` was involved the CLI wrote a config file before calling it. That was mostly needed when `hasura cli` was running inside container, there was no easy way to provide config via STDIN and then allow user input for interactive operations.
