### PR TITLE
Added --start-timeout flag with default value of 5 minutes

### DIFF
--- a/nhost/service/launcher.go
+++ b/nhost/service/launcher.go
@@ -59,12 +59,13 @@ func (l *Launcher) HasuraConsoleURL() string {
 	return l.mgr.HasuraConsoleURL()
 }
 
-func (l *Launcher) Start(ctx context.Context, debug bool) error {
+func (l *Launcher) Start(ctx context.Context, startTimeout time.Duration, debug bool) error {
+	l.l.Debugf("start timeout is set to %s", startTimeout.String())
 	if err := l.ensureInitialised(); err != nil {
 		return err
 	}
 
-	startCtx, cancel := context.WithTimeout(ctx, time.Minute*3)
+	startCtx, cancel := context.WithTimeout(ctx, startTimeout)
 	defer cancel()
 
 	return l.mgr.SyncExec(startCtx, func(cCtx context.Context) error {


### PR DESCRIPTION
## Description
Depending on project complexity the `nhost up` command may take a few minutes (pulling docker images on first run, downloading node_modules, etc) to complete.

## Solution
Add a flag `--start-timeout` with default value of 5 minutes