### PR TITLE
Named volumes for node_modules

### DIFF
--- a/nhost/compose/config.go
+++ b/nhost/compose/config.go
@@ -48,6 +48,11 @@ const (
 	svcTraefikDefaultImage   = "traefik:v2.8"
 	// --
 
+	// volume names
+	volFunctionsNodeModules = "functions_node_modules"
+	volRootNodeModules      = "root_node_modules"
+	// --
+
 	// environment variables
 
 	// envs prefixes
@@ -139,6 +144,12 @@ func (c *Config) build() *types.Config {
 		c.storageService(),
 		c.functionsService(),
 		c.mailhogService(),
+	}
+
+	// set volumes
+	config.Volumes = types.Volumes{
+		volFunctionsNodeModules: types.VolumeConfig{},
+		volRootNodeModules:      types.VolumeConfig{},
 	}
 
 	// loop over services and filter out nils, i.e. services that are not enabled
@@ -364,6 +375,16 @@ func (c Config) functionsService() *types.ServiceConfig {
 				Type:   types.VolumeTypeBind,
 				Source: "..",
 				Target: "/opt/project",
+			},
+			{
+				Type:   types.VolumeTypeVolume,
+				Source: volRootNodeModules,
+				Target: "/opt/project/node_modules",
+			},
+			{
+				Type:   types.VolumeTypeVolume,
+				Source: volFunctionsNodeModules,
+				Target: "/opt/project/functions/node_modules",
 			},
 		},
 	}

--- a/nhost/service/manager.go
+++ b/nhost/service/manager.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	slowStartWaitMsg = "It takes more than usual to start the nhost project. Most likely because CLI needs to pull js dependencies inside a container. Please wait..."
+	slowStartWaitMsg = "It takes longer than usual to start your Nhost project. Most likely because of the need to install your npm dependencies. Please wait."
 )
 
 type Manager interface {


### PR DESCRIPTION
## Description
- Use named docker volumes to persist `node_modules` from root and functions folder to prevent incompatibilities with host OS
- Edit the slow start message