### PR TITLE
fix: permission issue with seeds.applied file

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -59,7 +59,7 @@ var composeCmd = &cobra.Command{
 			return err
 		}
 
-		dc, err := compose.WrapperCmdWithExistingConfig(cmd.Context(), projectName, dcArgs, &compose.DataStreams{Stdout: os.Stdout, Stderr: os.Stderr})
+		dc, err := compose.CommandWithExistingConfig(cmd.Context(), projectName, dcArgs, &compose.DataStreams{Stdout: os.Stdout, Stderr: os.Stderr})
 		if err != nil {
 			return err
 		}

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -140,14 +140,22 @@ var devCmd = &cobra.Command{
 			return fmt.Errorf("failed to get git branch name: %v", err)
 		}
 
-		launcher := service.NewLauncher(
-			service.NewDockerComposeManager(config, hc, ports, env, gitBranchName,
-				projectName,
-				log,
-				status,
-				debug,
-			),
-			hc, ports, status, log)
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current working directory: %v", err)
+		}
+
+		dcMgr, err := service.NewDockerComposeManager(config, cwd, hc, ports, env, gitBranchName,
+			projectName,
+			log,
+			status,
+			debug,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to init docker compose manager: %v", err)
+		}
+
+		launcher := service.NewLauncher(dcMgr, hc, ports, status, log)
 
 		if err = launcher.Init(); err != nil {
 			return err

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -71,6 +71,11 @@ var logsCmd = &cobra.Command{
 			return fmt.Errorf("failed to read .env.development: %v", err)
 		}
 
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current working directory: %v", err)
+		}
+
 		gitRefGetter, err := git.NewReferenceGetterWithFallback()
 		if err != nil {
 			return fmt.Errorf("failed to init git ref getter: %v", err)
@@ -82,7 +87,12 @@ var logsCmd = &cobra.Command{
 		}
 
 		conf := compose.NewConfig(config, nil, env, gitBranchName, projectName)
-		dc, err := compose.WrapperCmd(cmd.Context(), dcArgs, conf, &compose.DataStreams{Stdout: os.Stdout, Stderr: os.Stderr})
+		dcWrapper, err := compose.InitWrapper(cwd, gitBranchName, conf)
+		if err != nil {
+			return err
+		}
+
+		dc, err := dcWrapper.Command(cmd.Context(), dcArgs, &compose.DataStreams{Stdout: os.Stdout, Stderr: os.Stderr})
 		if err != nil {
 			return err
 		}

--- a/nhost/compose/config.go
+++ b/nhost/compose/config.go
@@ -612,6 +612,10 @@ func (c Config) postgresServiceHealthcheck(interval, startPeriod time.Duration) 
 	}
 }
 
+func (c Config) postgresPgDataFolder() string {
+	return c.hostDataDirectoryBranchScoped(dataDirDb) + "/pgdata"
+}
+
 func (c Config) postgresService() *types.ServiceConfig {
 	return &types.ServiceConfig{
 		Name: SvcPostgres,
@@ -623,7 +627,7 @@ func (c Config) postgresService() *types.ServiceConfig {
 		Volumes: []types.ServiceVolumeConfig{
 			{
 				Type:   types.VolumeTypeBind,
-				Source: c.hostDataDirectoryBranchScoped(dataDirDb),
+				Source: c.postgresPgDataFolder(),
 				Target: envPostgresDataDefaultValue,
 			},
 		},

--- a/nhost/compose/config.go
+++ b/nhost/compose/config.go
@@ -31,12 +31,6 @@ const (
 	proxyPort   = 1337
 	// --
 
-	// data directory names
-	dataDirDb      = "db"
-	dataDirMailhog = "mailhog"
-	dataDirMinio   = "minio"
-	// --
-
 	// default docker images
 	svcPostgresDefaultImage  = "nhost/postgres:12-v0.0.6"
 	svcAuthDefaultImage      = "nhost/hasura-auth:0.10.0"
@@ -164,14 +158,6 @@ func (c *Config) build() *types.Config {
 	return config
 }
 
-func (c Config) hostDataDirectory(path string) string {
-	return filepath.Join("data", path)
-}
-
-func (c Config) hostDataDirectoryBranchScoped(path string) string {
-	return filepath.Join("data", path, c.gitBranch)
-}
-
 func (c *Config) BuildJSON() ([]byte, error) {
 	return json.MarshalIndent(c.build(), "", "  ")
 }
@@ -266,7 +252,7 @@ func (c Config) mailhogService() *types.ServiceConfig {
 		Volumes: []types.ServiceVolumeConfig{
 			{
 				Type:   types.VolumeTypeBind,
-				Source: c.hostDataDirectory(dataDirMailhog),
+				Source: MailHogDataDirGiBranchScopedPath(c.gitBranch),
 				Target: "/maildir",
 			},
 		},
@@ -320,7 +306,7 @@ func (c Config) minioService() *types.ServiceConfig {
 		Volumes: []types.ServiceVolumeConfig{
 			{
 				Type:   types.VolumeTypeBind,
-				Source: c.hostDataDirectory(dataDirMinio),
+				Source: MinioDataDirGitBranchScopedPath(c.gitBranch),
 				Target: "/data",
 			},
 		},
@@ -612,10 +598,6 @@ func (c Config) postgresServiceHealthcheck(interval, startPeriod time.Duration) 
 	}
 }
 
-func (c Config) postgresPgDataFolder() string {
-	return c.hostDataDirectoryBranchScoped(dataDirDb) + "/pgdata"
-}
-
 func (c Config) postgresService() *types.ServiceConfig {
 	return &types.ServiceConfig{
 		Name: SvcPostgres,
@@ -627,7 +609,7 @@ func (c Config) postgresService() *types.ServiceConfig {
 		Volumes: []types.ServiceVolumeConfig{
 			{
 				Type:   types.VolumeTypeBind,
-				Source: c.postgresPgDataFolder(),
+				Source: DbDataDirGitBranchScopedPath(c.gitBranch, dataDirPgdata),
 				Target: envPostgresDataDefaultValue,
 			},
 		},

--- a/nhost/compose/paths.go
+++ b/nhost/compose/paths.go
@@ -1,0 +1,29 @@
+package compose
+
+import "path/filepath"
+
+const (
+	// data directory names
+	dataDir        = "data"
+	dataDirDb      = "db"
+	dataDirPgdata  = "pgdata"
+	dataDirMailhog = "mailhog"
+	dataDirMinio   = "minio"
+	// --
+)
+
+func dataDirGitBranchScopedPath(gitBranch, path string) string {
+	return filepath.Join(dataDir, gitBranch, path)
+}
+
+func MinioDataDirGitBranchScopedPath(gitBranch string) string {
+	return dataDirGitBranchScopedPath(gitBranch, dataDirMinio)
+}
+
+func MailHogDataDirGiBranchScopedPath(gitBranch string) string {
+	return dataDirGitBranchScopedPath(gitBranch, dataDirMailhog)
+}
+
+func DbDataDirGitBranchScopedPath(gitBranch, path string) string {
+	return dataDirGitBranchScopedPath(gitBranch, filepath.Join(dataDirDb, path))
+}

--- a/nhost/compose/paths_test.go
+++ b/nhost/compose/paths_test.go
@@ -1,0 +1,106 @@
+package compose
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_dataDirGitBranchScopedPath(t *testing.T) {
+	type args struct {
+		gitBranch string
+		path      string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test",
+			args: args{
+				gitBranch: "feat/foo",
+				path:      "bar",
+			},
+			want: "data/feat/foo/bar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, dataDirGitBranchScopedPath(tt.args.gitBranch, tt.args.path), "dataDirGitBranchScopedPath(%v, %v)", tt.args.gitBranch, tt.args.path)
+		})
+	}
+}
+
+func TestMinioDataDirGitBranchScopedPath(t *testing.T) {
+	type args struct {
+		gitBranch string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test",
+			args: args{
+				gitBranch: "feat/foo",
+			},
+			want: "data/feat/foo/minio",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, MinioDataDirGitBranchScopedPath(tt.args.gitBranch), "MinioDataDirGitBranchScopedPath(%v)", tt.args.gitBranch)
+		})
+	}
+}
+
+func TestMailHogDataDirGiBranchScopedPath(t *testing.T) {
+	type args struct {
+		gitBranch string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test",
+			args: args{
+				gitBranch: "feat/foo",
+			},
+			want: "data/feat/foo/mailhog",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, MailHogDataDirGiBranchScopedPath(tt.args.gitBranch), "MailHogDataDirGiBranchScopedPath(%v)", tt.args.gitBranch)
+		})
+	}
+}
+
+func TestDbDataDirGitBranchScopedPath(t *testing.T) {
+	type args struct {
+		gitBranch string
+		path      string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test",
+			args: args{
+				gitBranch: "feat/foo",
+				path:      "bar",
+			},
+			want: "data/feat/foo/db/bar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, DbDataDirGitBranchScopedPath(tt.args.gitBranch, tt.args.path), "DbDataDirGitBranchScopedPath(%v, %v)", tt.args.gitBranch, tt.args.path)
+		})
+	}
+}

--- a/nhost/compose/wrapper.go
+++ b/nhost/compose/wrapper.go
@@ -36,7 +36,7 @@ func WrapperCmd(ctx context.Context, args []string, conf *Config, streams *DataS
 		filepath.Join(util.WORKING_DIR, ".nhost/data/minio"),
 		filepath.Join(util.WORKING_DIR, ".nhost/data/mailhog"),
 		filepath.Join(util.WORKING_DIR, ".nhost/custom/keys"),
-		filepath.Join(util.WORKING_DIR, ".nhost/data/db", conf.gitBranch),
+		filepath.Join(util.WORKING_DIR, ".nhost/data/db", conf.gitBranch, "pgdata"),
 	}
 
 	for _, folder := range paths {

--- a/nhost/compose/wrapper.go
+++ b/nhost/compose/wrapper.go
@@ -17,36 +17,64 @@ type DataStreams struct {
 	Stderr io.Writer
 }
 
-func WrapperCmd(ctx context.Context, args []string, conf *Config, streams *DataStreams) (*exec.Cmd, error) {
-	dockerComposeConfig, err := conf.BuildJSON()
-	if err != nil {
+type Wrapper struct {
+	workdir            string
+	composeProjectName string
+}
+
+func InitWrapper(workdir, gitBranch string, conf *Config) (*Wrapper, error) {
+	w := &Wrapper{
+		workdir:            workdir,
+		composeProjectName: conf.composeProjectName,
+	}
+
+	if err := w.init(workdir, gitBranch, conf); err != nil {
 		return nil, err
 	}
 
-	configFilename := filepath.Join(nhost.DOT_NHOST_DIR, "docker-compose.json")
+	return w, nil
+}
 
-	// write data to a docker-compose.yml file
-	err = os.WriteFile(configFilename, dockerComposeConfig, 0600)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not write docker-compose.yml file")
+func (w Wrapper) init(workdir, gitBranch string, conf *Config) error {
+	if err := w.ensureFoldersExistForDockerVolumes(workdir, gitBranch); err != nil {
+		return err
 	}
 
-	// check that data folders exist
+	jsonConf, err := conf.BuildJSON()
+
+	// write data to a docker-compose.yml file
+	err = os.WriteFile(w.dockerComposePath(), jsonConf, 0600)
+	if err != nil {
+		return errors.Wrap(err, "could not write docker-compose.yml file")
+	}
+	return nil
+}
+
+func (w Wrapper) dockerComposePath() string {
+	return filepath.Join(w.workdir, ".nhost/docker-compose.json")
+}
+
+func (w Wrapper) ensureFoldersExistForDockerVolumes(workdir, gitBranch string) error {
+	dotNhostFolder := filepath.Join(workdir, ".nhost")
+
 	paths := []string{
-		filepath.Join(util.WORKING_DIR, ".nhost/data/minio"),
-		filepath.Join(util.WORKING_DIR, ".nhost/data/mailhog"),
-		filepath.Join(util.WORKING_DIR, ".nhost/custom/keys"),
-		filepath.Join(util.WORKING_DIR, ".nhost/data/db", conf.gitBranch, "pgdata"),
+		filepath.Join(workdir, ".nhost/custom/keys"),
+		filepath.Join(dotNhostFolder, MinioDataDirGitBranchScopedPath(gitBranch)),
+		filepath.Join(dotNhostFolder, MailHogDataDirGiBranchScopedPath(gitBranch)),
+		filepath.Join(dotNhostFolder, DbDataDirGitBranchScopedPath(gitBranch, dataDirPgdata)),
 	}
 
 	for _, folder := range paths {
-		err = os.MkdirAll(folder, os.ModePerm)
-		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("failed to create data folder '%s'", folder))
+		if err := os.MkdirAll(folder, os.ModePerm); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed to create data folder '%s'", folder))
 		}
 	}
 
-	dc := exec.CommandContext(ctx, "docker", append([]string{"compose", "-p", conf.composeProjectName, "-f", configFilename}, args...)...)
+	return nil
+}
+
+func (w Wrapper) Command(ctx context.Context, args []string, streams *DataStreams) (*exec.Cmd, error) {
+	dc := exec.CommandContext(ctx, "docker", append([]string{"compose", "-p", w.composeProjectName, "-f", w.dockerComposePath()}, args...)...)
 
 	if streams != nil {
 		// set streams
@@ -58,7 +86,7 @@ func WrapperCmd(ctx context.Context, args []string, conf *Config, streams *DataS
 	return dc, nil
 }
 
-func WrapperCmdWithExistingConfig(ctx context.Context, projectName string, args []string, streams *DataStreams) (*exec.Cmd, error) {
+func CommandWithExistingConfig(ctx context.Context, projectName string, args []string, streams *DataStreams) (*exec.Cmd, error) {
 	configFilename := filepath.Join(nhost.DOT_NHOST_DIR, "docker-compose.json")
 
 	if !util.PathExists(configFilename) {


### PR DESCRIPTION
## Description
- Change docker volume mount path for postgres to avoid permission issue with `seeds.applied` file
- scope data folders for `minio`, `mailhog` and `postgres` with branch name

## Notes
A user can do the following to avoid loosing postgres data after upgrade:
- `mkdir -p .nhost/data/[branch]/db`
- `mv .nhost/data/db/[branch] .nhost/data/[branch]/db/pgdata` (prepend with sudo in case of permission issue)

