### PR TITLE
Pull objects on remote init from all schemas except "auth", "storage", "pg_*", "hdb_*"

### DIFF
--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -25,6 +25,7 @@ SOFTWARE.
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -128,6 +129,10 @@ func pgDumpSchemasFlags(schemas []string) []string {
 	return schemasFlags
 }
 
+func wrapFunctionsDump(dump []byte) []byte {
+	return bytes.ReplaceAll(dump, []byte("CREATE FUNCTION"), []byte("CREATE OR REPLACE FUNCTION"))
+}
+
 func pullMigration(client *hasura.Client, name string) (hasura.Migration, error) {
 
 	var args []string
@@ -176,11 +181,13 @@ func pullMigration(client *hasura.Client, name string) (hasura.Migration, error)
 
 		log.Debug("Creating initial migration")
 
-		migration.Data, err = client.Migration(pgDumpSchemasFlags(schemas))
+		migrationData, err := client.Migration(pgDumpSchemasFlags(schemas))
 		if err != nil {
 			log.Debug("Failed to get migration data")
 			return migration, err
 		}
+
+		migration.Data = wrapFunctionsDump(migrationData)
 
 		// create migration file
 		if err := os.MkdirAll(migration.Location, os.ModePerm); err != nil {

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -118,6 +118,16 @@ and sync them with your local app.`,
 	*/
 }
 
+func pgDumpSchemasFlags(schemas []string) []string {
+	var schemasFlags []string
+
+	for _, schema := range schemas {
+		schemasFlags = append(schemasFlags, "--schema", schema)
+	}
+
+	return schemasFlags
+}
+
 func pullMigration(client *hasura.Client, name string) (hasura.Migration, error) {
 
 	var args []string
@@ -166,7 +176,7 @@ func pullMigration(client *hasura.Client, name string) (hasura.Migration, error)
 
 		log.Debug("Creating initial migration")
 
-		migration.Data, err = client.Migration([]string{"--schema", "public"})
+		migration.Data, err = client.Migration(pgDumpSchemasFlags(schemas))
 		if err != nil {
 			log.Debug("Failed to get migration data")
 			return migration, err

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -166,7 +166,7 @@ func pullMigration(client *hasura.Client, name string) (hasura.Migration, error)
 
 		log.Debug("Creating initial migration")
 
-		migration.Data, err = client.Migration(migrationTables)
+		migration.Data, err = client.Migration([]string{"--schema", "public"})
 		if err != nil {
 			log.Debug("Failed to get migration data")
 			return migration, err

--- a/cmd/pull_test.go
+++ b/cmd/pull_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_pgDumpSchemasFlags(t *testing.T) {
+	type args struct {
+		schemas []string
+	}
+	tests := []struct {
+		name    string
+		schemas []string
+		want    []string
+	}{
+		{
+			name:    "test",
+			schemas: []string{"public", "my_schema1", "my_schema2"},
+			want:    []string{"--schema", "public", "--schema", "my_schema1", "--schema", "my_schema2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pgDumpSchemasFlags(tt.schemas); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("pgDumpSchemasFlags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/pull_test.go
+++ b/cmd/pull_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 )
@@ -27,4 +28,52 @@ func Test_pgDumpSchemasFlags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_wrapFunctionsDump(t *testing.T) {
+	dump := []byte(`
+CREATE FUNCTION public.set_current_timestamp_updated_at() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  _new record;
+BEGIN
+  _new := new;
+  _new. "updated_at" = now();
+  RETURN _new;
+END;
+$$;
+
+CREATE TABLE foo.bar (
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+);
+
+CREATE FUNCTION public.add(integer, integer) RETURNS integer
+    LANGUAGE sql IMMUTABLE STRICT
+    AS $_$select $1 + $2;$_$;
+`)
+
+	expected := []byte(`
+CREATE OR REPLACE FUNCTION public.set_current_timestamp_updated_at() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  _new record;
+BEGIN
+  _new := new;
+  _new. "updated_at" = now();
+  RETURN _new;
+END;
+$$;
+
+CREATE TABLE foo.bar (
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+);
+
+CREATE OR REPLACE FUNCTION public.add(integer, integer) RETURNS integer
+    LANGUAGE sql IMMUTABLE STRICT
+    AS $_$select $1 + $2;$_$;
+`)
+
+	assert.Equal(t, expected, wrapFunctionsDump(dump))
 }


### PR DESCRIPTION
## Description
Closes https://github.com/nhost/cli/issues/218

## Problem
Not all schema objects are pulled on `nhost init` with `--remote` flag

## Solution
Use pgdump API and pull all objects from all schemas except `auth`, `storage`, `pg_*`, `hdb_*`
