### PR TITLE
Use custom nhost/postgres image with correct roles

### DIFF
--- a/nhost/compose/wrapper.go
+++ b/nhost/compose/wrapper.go
@@ -74,12 +74,8 @@ func (w Wrapper) ensureFoldersExistForDockerVolumes(workdir, gitBranch string) e
 
 	// write pg_hba_local.conf
 	hbaFile := filepath.Join(dotNhostFolder, DbDataDirGitBranchScopedPath(gitBranch, "pg_hba_local.conf"))
-	hbaFileContent := `
-  local all all trust
-	host all all all trust
-	`
 
-	err := os.WriteFile(hbaFile, []byte(hbaFileContent), 0777)
+	err := os.WriteFile(hbaFile, []byte("local all all trust\nhost all all all trust"), 0777)
 	if err != nil {
 		return errors.Wrap(err, "could not write pg_hba_local.conf")
 	}

--- a/nhost/compose/wrapper.go
+++ b/nhost/compose/wrapper.go
@@ -3,13 +3,14 @@ package compose
 import (
 	"context"
 	"fmt"
-	"github.com/nhost/cli/nhost"
-	"github.com/nhost/cli/util"
-	"github.com/pkg/errors"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/nhost/cli/nhost"
+	"github.com/nhost/cli/util"
+	"github.com/pkg/errors"
 )
 
 type DataStreams struct {
@@ -47,6 +48,7 @@ func (w Wrapper) init(workdir, gitBranch string, conf *Config) error {
 	if err != nil {
 		return errors.Wrap(err, "could not write docker-compose.yml file")
 	}
+
 	return nil
 }
 
@@ -68,6 +70,18 @@ func (w Wrapper) ensureFoldersExistForDockerVolumes(workdir, gitBranch string) e
 		if err := os.MkdirAll(folder, os.ModePerm); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("failed to create data folder '%s'", folder))
 		}
+	}
+
+	// write pg_hba_local.conf
+	hbaFile := filepath.Join(dotNhostFolder, DbDataDirGitBranchScopedPath(gitBranch, "pg_hba_local.conf"))
+	hbaFileContent := `
+  local all all trust
+	host all all all trust
+	`
+
+	err := os.WriteFile(hbaFile, []byte(hbaFileContent), 0777)
+	if err != nil {
+		return errors.Wrap(err, "could not write pg_hba_local.conf")
 	}
 
 	return nil

--- a/nhost/service/manager.go
+++ b/nhost/service/manager.go
@@ -3,12 +3,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/nhost/cli/aws/s3client"
-	"github.com/nhost/cli/hasura"
-	"github.com/nhost/cli/nhost"
-	"github.com/nhost/cli/nhost/compose"
-	"github.com/nhost/cli/util"
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"os/exec"
@@ -17,6 +11,13 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/nhost/cli/aws/s3client"
+	"github.com/nhost/cli/hasura"
+	"github.com/nhost/cli/nhost"
+	"github.com/nhost/cli/nhost/compose"
+	"github.com/nhost/cli/util"
+	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/nhost/utils.go
+++ b/nhost/utils.go
@@ -2,15 +2,16 @@ package nhost
 
 import (
 	"fmt"
-	"github.com/docker/docker/pkg/namesgenerator"
-	"github.com/nhost/cli/util"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/docker/docker/pkg/namesgenerator"
+	"github.com/nhost/cli/util"
+	"gopkg.in/yaml.v2"
 )
 
 const (


### PR DESCRIPTION
## Description
Use custom postgres image `nhost/postgres:14.5` based on `postgres:14.5`

## Problem
With the work done to move away from AWS RDS, we are using a custom postgres image with specific roles for all services.

## Solution
Start using the custom postgres image and pass in the right roles to all services

## Notes
This version should only be used by projects already migrated from RDS.
