### PR TITLE
Fix detecting the location of .git for submodules

### DIFF
--- a/internal/git/reference_getter_with_fallback.go
+++ b/internal/git/reference_getter_with_fallback.go
@@ -41,7 +41,7 @@ func gitFolderLookup() (string, error) {
 	for {
 		gitPath := path + "/.git"
 		if util.PathExists(gitPath) {
-			return gitPath, nil
+			return path, nil
 		}
 
 		// If we are at the root, stop looking


### PR DESCRIPTION
## Description
Fixes detection of `.git` folder location for submodules

## Problem
`nhost dev` didn't work for submodules