### PR TITLE
fix: treat output of hasura cli correctly and honor custom binary

### DIFF
--- a/hasura/hasura.go
+++ b/hasura/hasura.go
@@ -53,8 +53,6 @@ func cliIsOutdated(existingCliPath, expectedVersion string) (bool, error) {
 		return false, err
 	}
 
-    fmt.Println(666, string(out))
-
 	var hv hasuraVersion
 	if err = json.Unmarshal(out, &hv); err != nil {
 		return false, err
@@ -79,10 +77,18 @@ func Binary(customBinary string) (string, error) {
 		return "", err
 	}
 
-	binaryPath := customBinary
-    if binaryPath == "" {
-        binaryPath = getBinary()
+    if customBinary != "" {
+		outdated, err := cliIsOutdated(customBinary, cliVersion)
+        if err != nil {
+            return "", err
+        }
+        if outdated {
+            return "", fmt.Errorf("specified %s is outdated", customBinary)
+        }
+        return customBinary, nil
     }
+
+    binaryPath := getBinary()
 
 	//  search for installed binary
 	if pathExists(binaryPath) {

--- a/hasura/hasura.go
+++ b/hasura/hasura.go
@@ -48,7 +48,7 @@ func cliIsOutdated(existingCliPath, expectedVersion string) (bool, error) {
 
 	// get a version of the existing CLI
 	cmd := exec.Command(existingCliPath, "version", "--skip-update-check")
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
 		return false, err
 	}

--- a/hasura/hasura.go
+++ b/hasura/hasura.go
@@ -53,6 +53,8 @@ func cliIsOutdated(existingCliPath, expectedVersion string) (bool, error) {
 		return false, err
 	}
 
+    fmt.Println(666, string(out))
+
 	var hv hasuraVersion
 	if err = json.Unmarshal(out, &hv); err != nil {
 		return false, err

--- a/hasura/hasura.go
+++ b/hasura/hasura.go
@@ -77,18 +77,18 @@ func Binary(customBinary string) (string, error) {
 		return "", err
 	}
 
-    if customBinary != "" {
+	if customBinary != "" {
 		outdated, err := cliIsOutdated(customBinary, cliVersion)
-        if err != nil {
-            return "", err
-        }
-        if outdated {
-            return "", fmt.Errorf("specified %s is outdated", customBinary)
-        }
-        return customBinary, nil
-    }
+		if err != nil {
+			return "", err
+		}
+		if outdated {
+			return "", fmt.Errorf("specified %s is outdated", customBinary)
+		}
+		return customBinary, nil
+	}
 
-    binaryPath := getBinary()
+	binaryPath := getBinary()
 
 	//  search for installed binary
 	if pathExists(binaryPath) {
@@ -137,7 +137,7 @@ func Binary(customBinary string) (string, error) {
 	}
 
 	status.Executing(fmt.Sprintf("Downloading %s binary for %s-%s", binary, runtime.GOOS, runtime.GOARCH))
-  log.Debugf("Downloading hasura cli from '%s'", url)
+	log.Debugf("Downloading hasura cli from '%s'", url)
 
 	resp, err := http.Get(url)
 	if err != nil {


### PR DESCRIPTION
## Description

1. Process only stdout of the command `hasura version`
2. Do not download hasura cli if the user 'hardcoded" the binary, instead error if it isn't the version we expect.

## Problem

When trying to detect the version of `hasura` we'd process both stdout and stderr but this can lead to errors as sometimes `hasura` will print debug statements under stderr, for instance:

```
{"level":"info","msg":"Help us improve Hasura! The cli collects anonymized usage stats which\nallow us to keep improving Hasura at warp speed. To opt-out or read more,\nvisit [https://hasura.io/docs/latest/graphql/core/guides/telemetry.html\n](https://hasura.io/docs/latest/graphql/core/guides/telemetry.html/n)","time":"2022-09-19T19:44:35Z"}
{"level":"info","msg":"hasura cli","time":"2022-09-19T19:44:35Z","version":"v2.10.1"}
```

In addition, if the user specified the binary to use for hasura but the version didn't match we'd try to download a newer version, however, this might not be what the user expected so it is better to error out and let the user know.

## Solution

1. Process only stdout
2. Error if user specifies hasura binary but isn't the correct version

## Notes
N/A

