### PR TITLE
fix: Fix docker compose project generation

### DIFF
--- a/nhost/utils_test.go
+++ b/nhost/utils_test.go
@@ -1,0 +1,16 @@
+package nhost
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func Test_randomProjectName(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.True(strings.HasPrefix(randomProjectName("test"), "test-"))
+	assert.True(strings.HasPrefix(randomProjectName("cookie monster (RAM)"), "cookie-monster-ram-"))
+	assert.True(strings.HasPrefix(randomProjectName("foo        + +    bar"), "foo-bar-"))
+	assert.True(strings.HasPrefix(randomProjectName("____bla-- bla _  2389 blaaaa ___"), "bla---bla-_-2389-blaaaa-"))
+}


### PR DESCRIPTION
## Description
`nhost up` may fail if project's folder name contains certain symbols like `(` or `)`. The project name for docker compose is comprised of a base name + random string.

## Solution
Filter out non alphanumeric and hyphen symbols in base name.
