### PR TITLE
Fix project init with --remote flag from homedir

### DIFF
--- a/hasura/hasura.go
+++ b/hasura/hasura.go
@@ -28,12 +28,13 @@ var status = &util.Writer
 var log = &logger.Log
 
 func getBinary() string {
-	switch runtime.GOOS {
-	case "windows":
-		return filepath.Join(nhost.ROOT, "hasura.exe")
-	default:
-		return filepath.Join(nhost.ROOT, "hasura")
+	hasuraExecName := "hasura"
+	if runtime.GOOS == "windows" {
+		hasuraExecName += ".exe"
 	}
+
+	// TODO: this is temporary, we should properly refactor paths calculation and avoid using global vars as well as usage of nhost.UpdateLocations() func
+	return filepath.Join(nhost.HOME, ".nhost", hasuraExecName)
 }
 
 func cliIsOutdated(existingCliPath, expectedVersion string) (bool, error) {


### PR DESCRIPTION
Closes https://github.com/nhost/cli/issues/350

## Description
Long-standing bug with `nhost init --remote` which kept failing with weird error `fork/exec $PROJECT_NAME/.nhost/hasura: no such file or directory`

## Problem
Apparently reproducible only if called from homedir 😄 
The reason is that the global var `nhost.ROOT` is mutated in https://github.com/nhost/cli/blob/fe711fb4f867370dad802a63ae922aeaac403dbf/nhost/vars.go#L170-L188 which may lead to incorrect path calculation when hasura client is initialised.

## Solution
Using `nhost.ROOT` var (which doesn't change) for hasura path forming

## Notes
This is a quick fix, a proper refactor is needed to remove global vars mutations and weird `nhost.UpdateLocations()` fun