### PR TITLE
Use native hasura cli on ARM arch

### DIFF
--- a/hasura/hasura.go
+++ b/hasura/hasura.go
@@ -113,9 +113,6 @@ func Binary(customBinary string) (string, error) {
 
 	//	Use AMD architecture instead of ARM
 	architecture := runtime.GOARCH
-	if strings.Contains(architecture, "arm") {
-		architecture = strings.ReplaceAll(architecture, "arm", "amd")
-	}
 
 	url = fmt.Sprintf("https://github.com/hasura/graphql-engine/releases/download/%v/cli-hasura-%v-%v", cliVersion, runtime.GOOS, architecture)
 


### PR DESCRIPTION
## Description
Use native arm build of hasura cli on arm architecture

## Problem
amd64 hasura cli works fine if `rosetta 2` installed, otherwise it doesn't run