### PR TITLE
Disallow "nhost init --remote" for projects with linked git repo

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -169,6 +169,11 @@ in the following manner:
 				}
 
 				selectedProject = projects[index]
+
+				if selectedProject.GithubRepository.Fullname != "" {
+					status.Fatal("Selected project is already connected to a GitHub repository. Please use `nhost up` inside this git project instead.")
+					return
+				}
 			}
 
 			location = strings.ReplaceAll(selectedProject.Name, " ", "_")

--- a/nhost/types.go
+++ b/nhost/types.go
@@ -30,13 +30,18 @@ type (
 		Apps []App  `json:"apps,omitempty"`
 	}
 
+	githubRepository struct {
+		Fullname string `json:"fullName"`
+	}
+
 	App struct {
-		ID                 string   `json:"id,omitempty"`
-		Name               string   `json:"name,omitempty"`
-		GraphQLAdminSecret string   `json:"hasuraGraphqlAdminSecret,omitempty"`
-		Subdomain          string   `json:"subdomain,omitempty"`
-		EnvVars            []EnvVar `json:"environmentVariables,omitempty"`
-		Workspace          string   `json:"workspace,omitempty"`
+		ID                 string           `json:"id,omitempty"`
+		Name               string           `json:"name,omitempty"`
+		GithubRepository   githubRepository `json:"githubRepository,omitempty"`
+		GraphQLAdminSecret string           `json:"hasuraGraphqlAdminSecret,omitempty"`
+		Subdomain          string           `json:"subdomain,omitempty"`
+		EnvVars            []EnvVar         `json:"environmentVariables,omitempty"`
+		Workspace          string           `json:"workspace,omitempty"`
 	}
 
 	EnvVar struct {


### PR DESCRIPTION
## Description
`nhost init --remote` may lead to migrations state inconsistencies in the cloud if the initialised project was already linked to a GitHub repository.

## Problem
`nhost init --remote` resets the hasura migrations state in the remote database after they are pulled via hasura api and persisted locally in a single migrations file. This doesn't do any effect on those projects which aren't linked to GitHub repos. In other case, this may break migrations if you have multiple locations where your project's code is stored. F.e. if you git cloned previously your GitHub project at `~/ab/c` and then called `nhost init --remote` and stored the project at `~/ab/d`. Migrations files will be different in those 2 locations, so in case of any changes in the original `~/ab/c` all further deployments will fail because of different timestamp value in migrations paths.

## Solution
Do not allow to initialise `nhost` projects from remote if they are linked to any GitHub repo.