### PR TITLE
Bump nhost/functions to 0.1.7

### DIFF
--- a/nhost/compose/config.go
+++ b/nhost/compose/config.go
@@ -37,7 +37,7 @@ const (
 	svcPostgresDefaultImage  = "nhost/postgres:14.5-20221009-1"
 	svcAuthDefaultImage      = "nhost/hasura-auth:0.13.2"
 	svcStorageDefaultImage   = "nhost/hasura-storage:0.2.4"
-	svcFunctionsDefaultImage = "nhost/functions:0.1.6"
+	svcFunctionsDefaultImage = "nhost/functions:0.1.7"
 	svcMinioDefaultImage     = "minio/minio:RELEASE.2022-07-08T00-05-23Z"
 	svcMailhogDefaultImage   = "mailhog/mailhog"
 	svcHasuraDefaultImage    = "hasura/graphql-engine:v2.10.1"


### PR DESCRIPTION
Avoid infinite loop on lock file change. Closes https://github.com/nhost/cli/issues/402