### PR TITLE
fix: add 'aarch64' to 'arch' matching

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -85,7 +85,7 @@ arch='unknown'
 archstr=`uname -m`
 if [[ "$archstr" == 'x86_64' ]]; then
     arch='amd64'
-elif [[ "$archstr" == 'arm64' ]]; then
+elif [[ "$archstr" == 'arm64' || "$archstr" == 'aarch64' ]]; then
     arch='arm64'
 else
     arch='386'


### PR DESCRIPTION
## Description
<!--
Use one of the following title prefix to categorize the pull request:
feat:   mark this pull request as a feature
fix:    mark this pull request as a bug fix
chore:  mark this pull request as a maintenance item

To auto merge this pull request when it was approved
by another member of the organization: set the label `auto-merge`
-->
## Problem
get.sh failed to match `aarch64` on Debian arm 

## Solution
add `aarch64` to get.sh `archstr` matching to download correct release
