### PR TITLE
fix: Corrected name of graphql service in docker-compose

### DIFF
--- a/nhost/compose/config.go
+++ b/nhost/compose/config.go
@@ -24,7 +24,7 @@ const (
 	SvcMailhog   = "mailhog"
 	SvcHasura    = "hasura"
 	SvcTraefik   = "traefik"
-	SvcGraphql   = "graphql"
+	SvcGraphql   = "hasura"
 	SvcDashboard = "dashboard"
 	// --
 


### PR DESCRIPTION
## Description
<!--
Use one of the following title prefix to categorize the pull request:
feat:   mark this pull request as a feature
fix:    mark this pull request as a bug fix
chore:  mark this pull request as a maintenance item

To auto merge this pull request when it was approved
by another member of the organization: set the label `auto-merge`
-->
## Problem
When I run `nhost up` on macOS 12.3.1 I get the following error:
```
$ nhost up --smtp-port 1026


> Failed to start services
> [exit status 1
no such service: hasura
] Failed to start services
```

## Solution
Changing the name of the docker-compose service to `hasura` here fixed the error:
https://github.com/remaininlight/nhost-cli/blob/c1d14da12ac21ee4bff858996dd129828a9cd8e8/nhost/compose/config.go#L27

## Notes
Other notes that you want to share but do not fit into _Problem_ or _Solution_.

