### PR TITLE
fix: docker-compose published port must be integer

### DIFF
--- a/nhost/compose/config.go
+++ b/nhost/compose/config.go
@@ -268,7 +268,7 @@ func (c Config) dashboardService() *types.ServiceConfig {
 			{
 				Mode:      "ingress",
 				Target:    3000,
-				Published: fmt.Sprint(c.ports.Dashboard()),
+				Published: c.ports.Dashboard(),
 				Protocol:  "tcp",
 			},
 		},
@@ -290,13 +290,13 @@ func (c Config) mailhogService() *types.ServiceConfig {
 			{
 				Mode:      "ingress",
 				Target:    1025,
-				Published: fmt.Sprint(c.ports.SMTP()),
+				Published: c.ports.SMTP(),
 				Protocol:  "tcp",
 			},
 			{
 				Mode:      "ingress",
 				Target:    8025,
-				Published: fmt.Sprint(c.ports.Mailhog()),
+				Published: c.ports.Mailhog(),
 				Protocol:  "tcp",
 			},
 		},
@@ -345,7 +345,7 @@ func (c Config) minioService() *types.ServiceConfig {
 			{
 				Mode:      "ingress",
 				Target:    9000,
-				Published: fmt.Sprint(c.ports.MinioS3()),
+				Published: c.ports.MinioS3(),
 				Protocol:  "tcp",
 			},
 			{
@@ -621,7 +621,7 @@ func (c Config) hasuraService() *types.ServiceConfig {
 			{
 				Mode:      "ingress",
 				Target:    graphqlPort,
-				Published: fmt.Sprint(c.ports.GraphQL()),
+				Published: c.ports.GraphQL(),
 				Protocol:  "tcp",
 			},
 		},
@@ -692,7 +692,7 @@ func (c Config) postgresService() *types.ServiceConfig {
 			{
 				Mode:      "ingress",
 				Target:    dbPort,
-				Published: fmt.Sprint(c.ports.DB()),
+				Published: c.ports.DB(),
 				Protocol:  "tcp",
 			},
 		},
@@ -708,7 +708,7 @@ func (c Config) traefikService() *types.ServiceConfig {
 			{
 				Mode:      "ingress",
 				Target:    proxyPort,
-				Published: fmt.Sprint(c.ports.Proxy()),
+				Published: c.ports.Proxy(),
 				Protocol:  "tcp",
 			},
 			{


### PR DESCRIPTION
## Description

## Problem
When I run `nhost up` on macOS 12.3.1 I get this error:
```
$ nhost up


> Failed to start services
> [exit status 15
services.traefik.ports.0.published must be a integer
] Failed to start services
```
This seems to be caused by docker-compose changing their config (from >= 2.3) to require integers for the published port:
https://github.com/docker/compose/issues/9306

## Solution
All `published` ports generated for the docker-compose file are now generated as integers rather than strings

Because `HostPort` (https://github.com/nhost/cli/compare/main...remaininlight:nhost-cli:fixed-docker-compose-published-port?expand=1#diff-02a255cf4e10d7bb679548ea0ba12fdd9e0babd0211db7561105e10d24ebe9d4L671) is a string which can be a range it is converted to an integer, taking the starting port from a range. I don't write Go very often, I'm sure there's room for improvement in that conversion function!

## Notes
Other notes that you want to share but do not fit into _Problem_ or _Solution_.

