### PR TITLE
chore: bump nhost/dashboard to 0.7.7

### DIFF
--- a/nhost/compose/config.go
+++ b/nhost/compose/config.go
@@ -35,7 +35,7 @@ const (
 	// --
 
 	// default docker images
-	svcDashboardDefaultImage = "nhost/dashboard:0.7.6"
+	svcDashboardDefaultImage = "nhost/dashboard:0.7.7"
 	svcPostgresDefaultImage  = "nhost/postgres:14.5-20221009-1"
 	svcAuthDefaultImage      = "nhost/hasura-auth:0.15.0"
 	svcStorageDefaultImage   = "nhost/hasura-storage:0.3.0"

--- a/nhost/compose/config_test.go
+++ b/nhost/compose/config_test.go
@@ -21,7 +21,7 @@ func TestConfig_dashboardService(t *testing.T) {
 
 	svc := c.dashboardService()
 	assert.Equal("dashboard", svc.Name)
-	assert.Equal("nhost/dashboard:0.7.6", svc.Image)
+	assert.Equal("nhost/dashboard:0.7.7", svc.Image)
 	assert.Equal([]types.ServicePortConfig{
 		{
 			Mode:      "ingress",


### PR DESCRIPTION
This PR bumps the Nhost Dashboard Docker image to version 0.7.7.