### PR TITLE
fix: update hasura/graphql-engine to v2.15.2

### DIFF
--- a/nhost/compose/config.go
+++ b/nhost/compose/config.go
@@ -42,7 +42,7 @@ const (
 	svcFunctionsDefaultImage = "nhost/functions:0.1.8"
 	svcMinioDefaultImage     = "minio/minio:RELEASE.2022-07-08T00-05-23Z"
 	svcMailhogDefaultImage   = "mailhog/mailhog"
-	svcHasuraDefaultImage    = "hasura/graphql-engine:v2.15.1"
+	svcHasuraDefaultImage    = "hasura/graphql-engine:v2.15.2"
 	svcTraefikDefaultImage   = "traefik:v2.8"
 	// --
 


### PR DESCRIPTION
## Description
<!--
Use one of the following title prefix to categorize the pull request:
feat:   mark this pull request as a feature
fix:    mark this pull request as a bug fix
chore:  mark this pull request as a maintenance item

To auto merge this pull request when it was approved
by another member of the organization: set the label `auto-merge`
-->

`nhost up` does not succeed.

![CleanShot 2022-12-08 at 08 47 55](https://user-images.githubusercontent.com/1271863/206321755-fab2ea31-1c89-45aa-a92d-4143727d84fc.png)

## Problem

hasura/graphql-engine (v2.15.1) image has been removed from the repository.
ref: https://hub.docker.com/r/hasura/graphql-engine

## Solution

I have updated the version of hasura/graphql-engine.

## Notes

![CleanShot 2022-12-08 at 09 08 10](https://user-images.githubusercontent.com/1271863/206324330-27ebfed8-ec19-49cf-ab49-e9a3cd0abe33.png)
![CleanShot 2022-12-08 at 09 09 08](https://user-images.githubusercontent.com/1271863/206324414-16068251-a06e-46bb-8700-87f1d00853ce.png)



