### PR TITLE
Add host.docker.internal as an extra host for systems where it's not set automatically

### DIFF
--- a/nhost/compose/config_test.go
+++ b/nhost/compose/config_test.go
@@ -41,3 +41,13 @@ func TestConfig_dashboardService(t *testing.T) {
 		"NEXT_TELEMETRY_DISABLED=1",
 	}), svc.Environment)
 }
+
+func TestConfig_addLocaldevExtraHost(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	c := &Config{}
+	svc := &types.ServiceConfig{}
+	c.addLocaldevExtraHost(svc)
+
+	assert.Equal(svc.ExtraHosts["host.docker.internal"], "host-gateway")
+}


### PR DESCRIPTION
## Description
`host.docker.internal` points to the host machine in `Docker for Mac`, but on some other installations f.e. on Linux it's not set.

## Problem
Impossible to talk to services running on the host machine on docker installations without `host.docker.internal` extra host.