### PR TITLE
feat: Adding debugger port to nodemon

### DIFF
--- a/nhost/compose/config.go
+++ b/nhost/compose/config.go
@@ -424,7 +424,7 @@ func (c Config) functionsService() *types.ServiceConfig {
 		Image:       c.serviceDockerImage(SvcFunctions, svcFunctionsDefaultImage),
 		Labels:      labels,
 		Restart:     types.RestartPolicyAlways,
-		Expose:      []string{"3000"},
+		Expose:      []string{"3000", "9229"},
 		Environment: c.functionsServiceEnvs().dockerServiceConfigEnv(),
 		HealthCheck: c.functionsServiceHealthcheck(time.Second*1, time.Minute*30), // 30 minutes is the maximum allowed time for a "functions" service to start, see more below
 		// Probe failure during that period will not be counted towards the maximum number of retries
@@ -445,6 +445,14 @@ func (c Config) functionsService() *types.ServiceConfig {
 				Type:   types.VolumeTypeVolume,
 				Source: volFunctionsNodeModules,
 				Target: "/opt/project/functions/node_modules",
+			},
+		},
+		Ports: []types.ServicePortConfig{
+			{
+				Mode:     "ingress",
+				Target:   9229,
+				Published: "9229",
+				Protocol: "tcp",
 			},
 		},
 	}


### PR DESCRIPTION
## Description
This pull request should allow us to use ```--inspect``` on functions container.

<!--
Use one of the following title prefix to categorize the pull request:
feat:   mark this pull request as a feature
fix:    mark this pull request as a bug fix
chore:  mark this pull request as a maintenance item

To auto merge this pull request when it was approved
by another member of the organization: set the label `auto-merge`
-->
## Problem
This PR intends to open the port so we can use a debugger on vscode or similar tools alongside nodemon.

## Solution
This PR exposes port 9229 used by nodemon to debug under the config.go file.


## Notes
none

