### PR TITLE
chore: bump nhost/dashboard to 0.11.13

### DIFF
--- a/nhost/compose/config.go
+++ b/nhost/compose/config.go
@@ -39,7 +39,7 @@ const (
 	// --
 
 	// default docker images
-	svcDashboardDefaultImage = "nhost/dashboard:0.11.6"
+	svcDashboardDefaultImage = "nhost/dashboard:0.11.13"
 	svcPostgresDefaultImage  = "nhost/postgres:14.5-20230104-1"
 	svcAuthDefaultImage      = "nhost/hasura-auth:0.17.0"
 	svcStorageDefaultImage   = "nhost/hasura-storage:0.3.0"

--- a/nhost/compose/config_test.go
+++ b/nhost/compose/config_test.go
@@ -21,7 +21,7 @@ func TestConfig_dashboardService(t *testing.T) {
 
 	svc := c.dashboardService()
 	assert.Equal("dashboard", svc.Name)
-	assert.Equal("nhost/dashboard:0.11.6", svc.Image)
+	assert.Equal("nhost/dashboard:0.11.13", svc.Image)
 	assert.Equal([]types.ServicePortConfig{
 		{
 			Mode:      "ingress",


### PR DESCRIPTION
This PR bumps the Nhost Dashboard Docker image to version 0.11.13.