### PR TITLE
Reload metadata to fix remote schemas from functions

### DIFF
--- a/hasura/client.go
+++ b/hasura/client.go
@@ -62,8 +62,8 @@ func (c *Client) Request(body []byte, path string) (*http.Response, error) {
 	return c.Client.Do(req)
 }
 
-//  Initialize the client with supplied Hasura endpoint,
-//  admin secret and a custom HTTP client.
+// Initialize the client with supplied Hasura endpoint,
+// admin secret and a custom HTTP client.
 func (c *Client) Init(endpoint, adminSecret, customBinary string, client HttpDoer) error {
 
 	log.Debug("Initializing Hasura client")
@@ -140,6 +140,16 @@ func (c *Client) ApplySeed(ctx context.Context, debug bool) error {
 
 func (c *Client) ExportMetadata(ctx context.Context, debug bool) error {
 	args := append([]string{"metadata", "export"}, c.CommonOptionsWithoutDB...)
+	cmd := exec.CommandContext(ctx, c.CLI, args...)
+	cmd.Dir = nhost.NHOST_DIR
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	setCmdDebugStreams(cmd, debug)
+
+	return nhost.RunCmdAndCaptureStderrIfNotSetup(cmd)
+}
+
+func (c *Client) ReloadMetadata(ctx context.Context, debug bool) error {
+	args := append([]string{"metadata", "reload"}, c.CommonOptionsWithoutDB...)
 	cmd := exec.CommandContext(ctx, c.CLI, args...)
 	cmd.Dir = nhost.NHOST_DIR
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/nhost/service/manager.go
+++ b/nhost/service/manager.go
@@ -160,6 +160,12 @@ func (m *dockerComposeManager) Start(ctx context.Context) error {
 		return err
 	}
 
+	// Reload Hasura Metadata
+	// This is needed because some remote schemas from functions might have been offline during the first metadata reload
+	if err := m.reloadMetadata(ctx); err != nil {
+		return err
+	}
+
 	// export metadata
 	// We export the metadata here because there might be new metadata from
 	// auth and storage that we want to sync locally.
@@ -386,6 +392,14 @@ func (m *dockerComposeManager) applyMetadata(ctx context.Context) error {
 	m.l.Debug("Applying metadata")
 
 	return m.hc.ApplyMetadata(ctx, m.debug)
+}
+
+func (m *dockerComposeManager) reloadMetadata(ctx context.Context) error {
+
+	m.status.Executing("Reloading metadata...")
+	m.l.Debug("Reloading metadata")
+
+	return m.hc.ReloadMetadata(ctx, m.debug)
 }
 
 func (m *dockerComposeManager) restartContainers(ctx context.Context, ds *compose.DataStreams, containers []string) error {


### PR DESCRIPTION
## Description

I've added a last step to reload Hasura Metadata for `nhost up`.

## Problem

When using a serverless function as a Remote Schema, Hasura had issues because the remote schema was not always available for Hasura when it needed to be.

## Solution

Reload the Hasura metadata as a last step.

Fixes: https://github.com/nhost/nhost/issues/1577