### PR TITLE
chore: bump nhost/dashboard to 0.13.2

### DIFF
--- a/nhost/compose/config.go
+++ b/nhost/compose/config.go
@@ -46,7 +46,7 @@ const (
 	// --
 
 	// default docker images
-	svcDashboardDefaultImage = "dashboard" // TODO: update image name before release
+	svcDashboardDefaultImage = "nhost/dashboard:0.13.2"
 	svcPostgresDefaultImage  = "nhost/postgres:14.5-20230104-1"
 	svcAuthDefaultImage      = "nhost/hasura-auth:0.19.0"
 	svcStorageDefaultImage   = "nhost/hasura-storage:0.3.0"

--- a/nhost/compose/config_test.go
+++ b/nhost/compose/config_test.go
@@ -38,6 +38,14 @@ func TestConfig_dashboardService(t *testing.T) {
 
 	svc := c.dashboardService()
 	assert.Equal("dashboard", svc.Name)
+	assert.Equal([]types.ServicePortConfig{
+		{
+			Mode:      "ingress",
+			Target:    3000,
+			Published: "3030",
+			Protocol:  "tcp",
+		},
+	}, svc.Ports)
 	assert.Equal(types.NewMappingWithEquals([]string{
 		"FOO=BAR",
 		"BAR=BAZ",


### PR DESCRIPTION
This PR bumps the Nhost Dashboard Docker image to version 0.13.2.