### PR TITLE
fix: set external url for http-based storage correctly

### DIFF
--- a/nhost/compose/config.go
+++ b/nhost/compose/config.go
@@ -2,9 +2,10 @@ package compose
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/nhost/cli/internal/ports"
 	"gopkg.in/yaml.v3"
-	"strings"
 
 	"github.com/compose-spec/compose-go/types"
 	"github.com/nhost/cli/nhost"
@@ -198,6 +199,10 @@ func (c Config) PublicHasuraConsoleRedirectURL() string {
 
 func (c Config) PublicStorageConnectionString() string {
 	return fmt.Sprintf("%s/v1", StorageHostname(c.ports.SSLProxy()))
+}
+
+func (c Config) httpStorageEnvPublicURL() string {
+	return HTTPStorageHostname(c.ports.Proxy())
 }
 
 func (c Config) storageEnvPublicURL() string {

--- a/nhost/compose/config_test.go
+++ b/nhost/compose/config_test.go
@@ -2,12 +2,13 @@ package compose
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/compose-spec/compose-go/types"
 	"github.com/nhost/cli/internal/ports"
 	"github.com/nhost/cli/nhost"
 	"github.com/nhost/cli/util"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func testPorts(t *testing.T) *ports.Ports {
@@ -160,7 +161,7 @@ func TestConfig_storageServiceEnvs(t *testing.T) {
 				nhostConfig: tt.nhostConfig,
 				ports:       tt.ports,
 			}
-			assert.Equalf(t, tt.want, c.storageServiceEnvs(tt.apiRootPrefix), "storageServiceEnvs()")
+			assert.Equalf(t, tt.want, c.storageServiceEnvs(tt.apiRootPrefix, "https://local.storage.nhost.run"), "storageServiceEnvs()")
 		})
 	}
 }

--- a/nhost/compose/hostnames.go
+++ b/nhost/compose/hostnames.go
@@ -52,6 +52,10 @@ func AuthHostname(port uint32) string {
 	return sslHostnameWithPort(HostLocalAuthNhostRun, port)
 }
 
+func HTTPStorageHostname(port uint32) string {
+	return httpHostnameWithPort(HostLocalDashboardNhostRun, port)
+}
+
 func StorageHostname(port uint32) string {
 	return sslHostnameWithPort(HostLocalStorageNhostRun, port)
 }

--- a/nhost/compose/svc_storage.go
+++ b/nhost/compose/svc_storage.go
@@ -2,11 +2,12 @@ package compose
 
 import (
 	"fmt"
+
 	"github.com/compose-spec/compose-go/types"
 	"github.com/nhost/cli/util"
 )
 
-func (c Config) storageServiceEnvs(apiRootPrefix string) env {
+func (c Config) storageServiceEnvs(apiRootPrefix, publicURL string) env {
 	minioEnv := c.minioServiceEnvs()
 	s3Endpoint := "http://minio:9000"
 
@@ -19,7 +20,7 @@ func (c Config) storageServiceEnvs(apiRootPrefix string) env {
 	e := env{
 		"DEBUG":                       "true",
 		"BIND":                        ":8576",
-		"PUBLIC_URL":                  c.storageEnvPublicURL(),
+		"PUBLIC_URL":                  publicURL,
 		"API_ROOT_PREFIX":             apiRootPrefix,
 		"POSTGRES_MIGRATIONS":         "1",
 		"HASURA_METADATA":             "1",
@@ -56,7 +57,7 @@ func (c Config) httpStorageService() *types.ServiceConfig {
 		Name:        "http-" + SvcStorage,
 		Restart:     types.RestartPolicyAlways,
 		Image:       c.serviceDockerImage(SvcStorage, svcStorageDefaultImage),
-		Environment: c.storageServiceEnvs("/v1/storage").dockerServiceConfigEnv(),
+		Environment: c.storageServiceEnvs("/v1/storage", c.httpStorageEnvPublicURL()).dockerServiceConfigEnv(),
 		Labels:      httpLabels.AsMap(),
 		Command:     []string{"serve"},
 	}
@@ -75,7 +76,7 @@ func (c Config) storageService() *types.ServiceConfig {
 		Name:        SvcStorage,
 		Restart:     types.RestartPolicyAlways,
 		Image:       c.serviceDockerImage(SvcStorage, svcStorageDefaultImage),
-		Environment: c.storageServiceEnvs("").dockerServiceConfigEnv(),
+		Environment: c.storageServiceEnvs("", c.storageEnvPublicURL()).dockerServiceConfigEnv(),
 		Labels:      sslLabels.AsMap(),
 		Command:     []string{"serve"},
 	}


### PR DESCRIPTION
When we launched the new SSL endpoints the old one should've worked as usual for backward compatibility reasons. However, due to a bug, requesting presigned urls to the storage using the old endpoint returned an invalid url pointing to the new endpoint.

This PR fixes that behaviour and ensures that presigned URLs for the same endpoint are return correctly.