### PR TITLE
feat: allow using .env.development to override defined env vars

### DIFF
--- a/clienv/filesystem.go
+++ b/clienv/filesystem.go
@@ -29,6 +29,10 @@ func (p PathStructure) Root() string {
 	return p.root
 }
 
+func (p PathStructure) EnvDevelopment() string {
+	return filepath.Join(p.Root(), ".env.development")
+}
+
 func (p PathStructure) DotNhostFolder() string {
 	return p.dotNhostFolder
 }

--- a/cmd/project/init.go
+++ b/cmd/project/init.go
@@ -97,7 +97,7 @@ func initInit(
 	}
 	defer gitingoref.Close()
 
-	if err := system.AddToGitignore(fs.Secrets()); err != nil {
+	if err := system.AddToGitignore(".secrets"); err != nil {
 		return fmt.Errorf("failed to add secrets to .gitignore: %w", err)
 	}
 

--- a/dockercompose/compose.go
+++ b/dockercompose/compose.go
@@ -554,10 +554,10 @@ func console( //nolint:funlen
 	nhostFolder string,
 ) (*Service, error) {
 	if semver.Compare(*cfg.GetHasura().GetVersion(), minimumHasuraVerson) < 0 {
-		return nil, fmt.Errorf(
+		return nil, fmt.Errorf( //nolint:goerr113
 			"hasura version must be at least %s",
 			minimumHasuraVerson,
-		) //nolint:goerr113
+		)
 	}
 
 	graphql, err := graphql(cfg, useTLS)


### PR DESCRIPTION
Solves https://github.com/nhost/nhost.toml/issues/1

The idea is as follows to replace the values of environment variables in `[[ global.environment]]` with the values defined in `.env.development`. It is important to note that this functionality only REPLACES, it does NOT add environment variables, for the override to work the env var needs to be defined first.