### PR TITLE
chore: bump nhost/dashboard to 0.16.11

### DIFF
--- a/dockercompose/compose.go
+++ b/dockercompose/compose.go
@@ -646,7 +646,7 @@ func console( //nolint:funlen
 
 func dashboard(cfg *model.ConfigConfig, useTLS bool) *Service {
 	return &Service{
-		Image:      "nhost/dashboard:0.14.1",
+		Image:      "nhost/dashboard:0.16.11",
 		DependsOn:  nil,
 		EntryPoint: nil,
 		Command:    nil,


### PR DESCRIPTION
This PR bumps the Nhost Dashboard Docker image to version 0.16.11.