### PR TITLE
Fix: typo

### DIFF
--- a/cmd/project/list.go
+++ b/cmd/project/list.go
@@ -13,7 +13,7 @@ func CommandList() *cli.Command {
 	return &cli.Command{ //nolint:exhaustruct
 		Name:    "list",
 		Aliases: []string{},
-		Usage:   "Lst remote apps",
+		Usage:   "List remote apps",
 		Action:  commandList,
 		Flags:   []cli.Flag{},
 	}


### PR DESCRIPTION
## Description

`i` missing on  help info on`List` command



## Notes

![CleanShot 2023-06-05 at 09 07 02](https://github.com/nhost/cli/assets/13418668/2c362b13-4b11-4fe7-8a25-dd102c13a5d6)

