### PR TITLE
feat: allow specifying subdomain when working with remote environments

### DIFF
--- a/clienv/wf_app_info.go
+++ b/clienv/wf_app_info.go
@@ -4,14 +4,49 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/nhost/cli/nhostclient/graphql"
 )
 
-func (ce *CliEnv) GetAppInfo(
+func getRemoteAppInfo(
 	ctx context.Context,
+	ce *CliEnv,
+	subdomain string,
 ) (*graphql.GetWorkspacesApps_Workspaces_Apps, error) {
+	session, err := ce.LoadSession(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load session: %w", err)
+	}
+
+	cl := ce.GetNhostClient()
+	workspaces, err := cl.GetWorkspacesApps(
+		ctx,
+		graphql.WithAccessToken(session.Session.AccessToken),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workspaces: %w", err)
+	}
+
+	for _, workspace := range workspaces.Workspaces {
+		for _, app := range workspace.Apps {
+			if app.Subdomain == subdomain {
+				return app, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("failed to find app with subdomain: %s", subdomain) //nolint:goerr113
+}
+
+func (ce *CliEnv) GetAppInfo(
+	ctx context.Context, subdomain string,
+) (*graphql.GetWorkspacesApps_Workspaces_Apps, error) {
+	if subdomain != "" {
+		return getRemoteAppInfo(ctx, ce, subdomain)
+	}
+
 	var project *graphql.GetWorkspacesApps_Workspaces_Apps
 	if err := UnmarshalFile(ce.Path.ProjectFile(), &project, json.Unmarshal); err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import "github.com/urfave/cli/v2"
 
+const flagSubdomain = "subdomain"
+
 func Command() *cli.Command {
 	return &cli.Command{ //nolint:exhaustruct
 		Name:    "config",

--- a/cmd/config/pull.go
+++ b/cmd/config/pull.go
@@ -28,7 +28,13 @@ func CommandPull() *cli.Command {
 		Aliases: []string{},
 		Usage:   "Get cloud configuration",
 		Action:  commandPull,
-		Flags:   []cli.Flag{},
+		Flags: []cli.Flag{
+			&cli.StringFlag{ //nolint:exhaustruct
+				Name:    flagSubdomain,
+				Usage:   "Pull this subdomain's configuration. Defaults to linked project",
+				EnvVars: []string{"NHOST_SUBDOMAIN"},
+			},
+		},
 	}
 }
 
@@ -42,7 +48,7 @@ func commandPull(cCtx *cli.Context) error {
 		return err
 	}
 
-	proj, err := ce.GetAppInfo(cCtx.Context)
+	proj, err := ce.GetAppInfo(cCtx.Context, cCtx.String(flagSubdomain))
 	if err != nil {
 		return fmt.Errorf("failed to get app info: %w", err)
 	}

--- a/cmd/config/show.go
+++ b/cmd/config/show.go
@@ -8,22 +8,18 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const (
-	flagSkipPatches = "skip-patches"
-)
-
 func CommandShow() *cli.Command {
 	return &cli.Command{ //nolint:exhaustruct
-		Name:    "show",
-		Aliases: []string{},
-		Usage:   "Shows configuration after applying jsonpatches and resolving secrets",
-		Action:  commandShow,
+		Name:        "show",
+		Aliases:     []string{},
+		Usage:       "Shows configuration after resolving secrets",
+		Description: "Note that this command will always use the local secrets, even if you specify subdomain",
+		Action:      commandShow,
 		Flags: []cli.Flag{
-			&cli.BoolFlag{ //nolint:exhaustruct
-				Name:    flagSkipPatches,
-				Usage:   "Skip applying jsonpatches",
-				Value:   false,
-				EnvVars: []string{"NHOST_SKIP_PATCHES"},
+			&cli.StringFlag{ //nolint:exhaustruct
+				Name:    flagSubdomain,
+				Usage:   "Show this subdomain's rendered configuration. Defaults to base configuration",
+				EnvVars: []string{"NHOST_SUBDOMAIN"},
 			},
 		},
 	}
@@ -32,7 +28,7 @@ func CommandShow() *cli.Command {
 func commandShow(c *cli.Context) error {
 	ce := clienv.FromCLI(c)
 
-	cfg, err := Validate(ce, !c.Bool(flagSkipPatches))
+	cfg, err := Validate(ce, c.String(flagSubdomain))
 	if err != nil {
 		return err
 	}

--- a/cmd/config/validate_test.go
+++ b/cmd/config/validate_test.go
@@ -187,36 +187,6 @@ func TestValidate(t *testing.T) {
 			expected:     expectedConfig,
 			applyPatches: true,
 		},
-		{
-			name: "skippatches",
-			path: "success",
-			expected: func() *model.ConfigConfig {
-				cfg := expectedConfig()
-
-				cfg.Global.Environment = []*model.ConfigEnvironmentVariable{
-					{
-						Name:  "ENVIRONMENT",
-						Value: "production",
-					},
-				}
-
-				cfg.Hasura.Version = ptr("v2.24.1-ce")
-
-				cfg.Auth.Redirections.ClientUrl = ptr("https://my.app.com")
-
-				cfg.Auth.Method.Oauth.Apple = &model.ConfigAuthMethodOauthApple{
-					Enabled:    ptr(true),
-					ClientId:   ptr("clientID"),
-					KeyId:      ptr("keyID"),
-					TeamId:     ptr("teamID"),
-					PrivateKey: ptr("privateKey"),
-					Scope:      nil,
-				}
-
-				return cfg
-			},
-			applyPatches: false,
-		},
 	}
 
 	for _, tc := range cases {

--- a/cmd/config/validate_test.go
+++ b/cmd/config/validate_test.go
@@ -236,10 +236,10 @@ func TestValidate(t *testing.T) {
 					filepath.Join("testdata", "validate", tc.path, "nhost"),
 				),
 				"fakedomain",
-				"fakeproject",
+				"",
 			)
 
-			cfg, err := config.Validate(ce, tc.applyPatches)
+			cfg, err := config.Validate(ce, "local")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -153,7 +153,7 @@ func up(
 		cancel()
 	}()
 
-	cfg, err := config.Validate(ce, true)
+	cfg, err := config.Validate(ce, "local")
 	if err != nil {
 		return fmt.Errorf("failed to validate config: %w", err)
 	}

--- a/cmd/project/init.go
+++ b/cmd/project/init.go
@@ -135,7 +135,7 @@ func InitRemote(
 	ctx context.Context,
 	ce *clienv.CliEnv,
 ) error {
-	proj, err := ce.GetAppInfo(ctx)
+	proj, err := ce.GetAppInfo(ctx, "")
 	if err != nil {
 		return fmt.Errorf("failed to get app info: %w", err)
 	}

--- a/cmd/secrets/create.go
+++ b/cmd/secrets/create.go
@@ -15,7 +15,7 @@ func CommandCreate() *cli.Command {
 		Aliases:   []string{},
 		Usage:     "Create secret in the cloud environment",
 		Action:    commandCreate,
-		Flags:     []cli.Flag{},
+		Flags:     commonFlags(),
 	}
 }
 
@@ -25,7 +25,7 @@ func commandCreate(cCtx *cli.Context) error {
 	}
 
 	ce := clienv.FromCLI(cCtx)
-	proj, err := ce.GetAppInfo(cCtx.Context)
+	proj, err := ce.GetAppInfo(cCtx.Context, cCtx.String(flagSubdomain))
 	if err != nil {
 		return fmt.Errorf("failed to get app info: %w", err)
 	}

--- a/cmd/secrets/delete.go
+++ b/cmd/secrets/delete.go
@@ -15,7 +15,7 @@ func CommandDelete() *cli.Command {
 		Aliases:   []string{},
 		Usage:     "Delete secret in the cloud environment",
 		Action:    commandDelete,
-		Flags:     []cli.Flag{},
+		Flags:     commonFlags(),
 	}
 }
 
@@ -25,7 +25,7 @@ func commandDelete(cCtx *cli.Context) error {
 	}
 
 	ce := clienv.FromCLI(cCtx)
-	proj, err := ce.GetAppInfo(cCtx.Context)
+	proj, err := ce.GetAppInfo(cCtx.Context, cCtx.String(flagSubdomain))
 	if err != nil {
 		return fmt.Errorf("failed to get app info: %w", err)
 	}

--- a/cmd/secrets/list.go
+++ b/cmd/secrets/list.go
@@ -14,14 +14,14 @@ func CommandList() *cli.Command {
 		Aliases: []string{},
 		Usage:   "List secrets in the cloud environment",
 		Action:  commandList,
-		Flags:   []cli.Flag{},
+		Flags:   commonFlags(),
 	}
 }
 
 func commandList(cCtx *cli.Context) error {
 	ce := clienv.FromCLI(cCtx)
 
-	proj, err := ce.GetAppInfo(cCtx.Context)
+	proj, err := ce.GetAppInfo(cCtx.Context, cCtx.String(flagSubdomain))
 	if err != nil {
 		return fmt.Errorf("failed to get app info: %w", err)
 	}

--- a/cmd/secrets/secrets.go
+++ b/cmd/secrets/secrets.go
@@ -2,6 +2,18 @@ package secrets
 
 import "github.com/urfave/cli/v2"
 
+const flagSubdomain = "subdomain"
+
+func commonFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{ //nolint:exhaustruct
+			Name:    flagSubdomain,
+			Usage:   "Project's subdomain to operate on, defaults to linked project",
+			EnvVars: []string{"NHOST_SUBDOMAIN"},
+		},
+	}
+}
+
 func Command() *cli.Command {
 	return &cli.Command{ //nolint:exhaustruct
 		Name:    "secrets",

--- a/cmd/secrets/update.go
+++ b/cmd/secrets/update.go
@@ -15,7 +15,7 @@ func CommandUpdate() *cli.Command {
 		Aliases:   []string{},
 		Usage:     "Update secret in the cloud environment",
 		Action:    commandUpdate,
-		Flags:     []cli.Flag{},
+		Flags:     commonFlags(),
 	}
 }
 
@@ -25,7 +25,7 @@ func commandUpdate(cCtx *cli.Context) error {
 	}
 
 	ce := clienv.FromCLI(cCtx)
-	proj, err := ce.GetAppInfo(cCtx.Context)
+	proj, err := ce.GetAppInfo(cCtx.Context, cCtx.String(flagSubdomain))
 	if err != nil {
 		return fmt.Errorf("failed to get app info: %w", err)
 	}


### PR DESCRIPTION
Solves #465

If no subdomain is specified, defaults to the linked project.

```
❯ nhost config validate --remote
Getting secrets...
Config is valid!

❯ nhost --subdomain yuimvxekebusfkiwfexo config validate --remote
Getting secrets...
main.go:59: failed to validate config: failed to render config tempolate: failed to render template: variable not found: secrets.APPLE_CLIENT_ID
exit status 1
```

```
❯ nhost secrets create MY_SECRET 456
Secret created successfully!

❯ nhost --subdomain yuimvxekebusfkiwfexo secrets create MY_SECRET 123
Secret created successfully!
```