### PR TITLE
chore: bump nhost/dashboard to 0.17.20

### DIFF
--- a/dockercompose/compose.go
+++ b/dockercompose/compose.go
@@ -250,7 +250,7 @@ func minio(dataFolder string) (*Service, error) {
 
 func dashboard(cfg *model.ConfigConfig, httpPort uint, useTLS bool) *Service {
 	return &Service{
-		Image:      "nhost/dashboard:0.17.18",
+		Image:      "nhost/dashboard:0.17.20",
 		DependsOn:  nil,
 		EntryPoint: nil,
 		Command:    nil,


### PR DESCRIPTION
This PR bumps the Nhost Dashboard Docker image to version 0.17.20.