### PR TITLE
fix:Add upper case verification for cli prompts

### DIFF
--- a/cmd/config/pull.go
+++ b/cmd/config/pull.go
@@ -72,7 +72,7 @@ func verifyFile(ce *clienv.CliEnv, name string) error {
 		if err != nil {
 			return fmt.Errorf("failed to read input: %w", err)
 		}
-		if resp != "y" {
+		if resp != "y" && resp != "Y" {
 			return fmt.Errorf("aborting") //nolint:goerr113
 		}
 	}

--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -292,7 +292,7 @@ func Up(
 			ce.Warnln("failed to read input: %s", err)
 			return nil
 		}
-		if resp != "y" {
+		if resp != "y" && resp != "Y" {
 			return nil
 		}
 


### PR DESCRIPTION
## Description

`nhost config pull` aborts when users passes in 'Y' (upper case). 

## Problem
During the migration [away from Cobra cli](https://github.com/nhost/cli/pull/667/files#diff-05feb559e87ca0f962a3b449103033c6416fefe957077a75ccc69e29fd82aa19R67), a corner case was missed to support upper case from the user prompt.
```
nhost config pull
- nhost/nhost.toml already exists. Do you want to overwrite it? [y/N] Y
main.go:59: aborting
```

## Solution
Extend the check to include upper case of 'Y' in the two cases found wher

## Notes
Tested by building locally and getting a positive output 
``` ~/go/src/tools/cli/nhosttest config pull
- nhost/nhost.toml already exists. Do you want to overwrite it? [y/N] Y
- .secrets already exists. Do you want to overwrite it? [y/N] Y
Pulling config from Nhost...
Getting secrets list from Nhost...
Adding .secrets to .gitignore...
Success!
- Review `nhost/nhost.toml` and make sure there are no secrets before you commit it to git.
- Review `.secrets` file and set your development secrets
- Review `.secrets` was added to .gitignore
```

