### PR TITLE
chore: bump nhost/dashboard to 1.3.0

### DIFF
--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -92,7 +92,7 @@ func CommandUp() *cli.Command { //nolint:funlen
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:0.21.1",
+				Value:   "nhost/dashboard:1.3.0",
 				EnvVars: []string{"NHOST_DASHBOARD_VERSION"},
 			},
 		},


### PR DESCRIPTION
This PR bumps the Nhost Dashboard Docker image to version 1.3.0.