### PR TITLE
chore: bump nhost/dashboard to 1.6.7

### DIFF
--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -105,7 +105,7 @@ func CommandUp() *cli.Command { //nolint:funlen
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:1.6.3",
+				Value:   "nhost/dashboard:1.6.7",
 				EnvVars: []string{"NHOST_DASHBOARD_VERSION"},
 			},
 			&cli.StringSliceFlag{ //nolint:exhaustruct


### PR DESCRIPTION
This PR bumps the Nhost Dashboard Docker image to version 1.6.7.