### PR TITLE
fix: hide apply metadata errors and verify metadata in the end

### DIFF
--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -198,6 +198,19 @@ func restart(
 	return nil
 }
 
+func reload(
+	ctx context.Context,
+	ce *clienv.CliEnv,
+	dc *dockercompose.DockerCompose,
+) error {
+	ce.Infoln("Reapplying metadata...")
+	if err := dc.ReloadMetadata(ctx); err != nil {
+		return fmt.Errorf("failed to reapply metadata: %w", err)
+	}
+
+	return nil
+}
+
 func parseRunServiceConfigFlag(value string) (string, string, error) {
 	parts := strings.Split(value, ":")
 	switch len(parts) {
@@ -323,6 +336,10 @@ func up( //nolint:funlen
 		"--admin-secret", cfg.Hasura.AdminSecret,
 	); err != nil {
 		return fmt.Errorf("failed to create metadata: %w", err)
+	}
+
+	if err := reload(ctx, ce, dc); err != nil {
+		return err
 	}
 
 	ce.Infoln("Nhost development environment started.")

--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -249,7 +249,7 @@ func processRunServices(
 	return r, nil
 }
 
-func up( //nolint:funlen
+func up( //nolint:funlen,cyclop
 	ctx context.Context,
 	ce *clienv.CliEnv,
 	dc *dockercompose.DockerCompose,

--- a/dockercompose/dockercompose.go
+++ b/dockercompose/dockercompose.go
@@ -151,6 +151,28 @@ func (dc *DockerCompose) ApplyMetadata(ctx context.Context) error {
 		"--skip-update-check",
 	)
 
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run docker compose: %w", err)
+	}
+
+	return nil
+}
+
+func (dc *DockerCompose) ReloadMetadata(ctx context.Context) error {
+	cmd := exec.CommandContext( //nolint:gosec
+		ctx,
+		"docker", "compose",
+		"--project-directory", dc.workingDir,
+		"-f", dc.filepath,
+		"-p", dc.projectName,
+		"exec",
+		"console",
+		"hasura-cli",
+		"metadata", "reload",
+		"--endpoint", "http://graphql:8080",
+		"--skip-update-check",
+	)
+
 	f, err := pty.Start(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to start pty: %w", err)


### PR DESCRIPTION
This is to avoid confusing the user with transient metadata inconsistencies.