### PR TITLE
chore: bump nhost/dashboard to 1.12.2

### DIFF
--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -106,7 +106,7 @@ func CommandUp() *cli.Command { //nolint:funlen
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:1.12.1",
+				Value:   "nhost/dashboard:1.12.2",
 				EnvVars: []string{"NHOST_DASHBOARD_VERSION"},
 			},
 			&cli.StringFlag{ //nolint:exhaustruct


### PR DESCRIPTION
This PR bumps the Nhost Dashboard Docker image to version 1.12.2.