### PR TITLE
fix: don't remove `v` from the version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else
   OS?=linux
 endif
 
-VER=$(shell echo $(VERSION) | sed -e 's/^v//g' -e 's/\//_/g')
+VER=$(shell echo $(VERSION) | sed -e -e 's/\//_/g')
 
 
 .PHONY: check

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else
   OS?=linux
 endif
 
-VER=$(shell echo $(VERSION) | sed -e -e 's/\//_/g')
+VER=$(shell echo $(VERSION) | sed -e 's/\//_/g')
 
 
 .PHONY: check

--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
         tags = [ ];
 
         ldflags = [
-          "-X main.Version=v${version}"
+          "-X main.Version=${version}"
         ];
       in
       {

--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
         tags = [ ];
 
         ldflags = [
-          "-X main.Version=${version}"
+          "-X main.Version=v${version}"
         ];
       in
       {

--- a/software/sofware.go
+++ b/software/sofware.go
@@ -65,7 +65,7 @@ func (mgr *Manager) GetReleases(ctx context.Context, version string) (Releases, 
 	for _, release := range releases {
 		switch {
 		case release.Prerelease:
-		case semver.Compare(version, release.TagName) > 0:
+		case semver.Compare(version, release.TagName) >= 0:
 		default:
 			r = append(r, release)
 		}


### PR DESCRIPTION
Fixes #859