### PR TITLE
chore: bump nhost/dashboard to 1.19.0

### DIFF
--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -109,7 +109,7 @@ func CommandUp() *cli.Command { //nolint:funlen
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:1.13.3",
+				Value:   "nhost/dashboard:1.19.0",
 				EnvVars: []string{"NHOST_DASHBOARD_VERSION"},
 			},
 			&cli.StringFlag{ //nolint:exhaustruct


### PR DESCRIPTION
### **User description**
This PR bumps the Nhost Dashboard Docker image to version 1.19.0.


___

### **PR Type**
enhancement


___

### **Description**
- Updated the Nhost Dashboard Docker image version to 1.19.0 in the `cmd/dev/up.go` file.
- This change ensures that the latest features and fixes in the Nhost Dashboard are included.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>up.go</strong><dd><code>Bump Nhost Dashboard version to 1.19.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
cmd/dev/up.go

<li>Updated the default value for the <code>flagDashboardVersion</code> to <br><code>nhost/dashboard:1.19.0</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/nhost/cli/pull/868/files#diff-b5263420bb6de52a7fe9a32d559b072b12707f31b6c44ca720c2e93cc15b17e2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

