### PR TITLE
feat: added support for nodejs 20 alongside nodejs 18

### DIFF
--- a/cmd/config/example.go
+++ b/cmd/config/example.go
@@ -104,6 +104,7 @@ func commandExample(cCtx *cli.Context) error { //nolint:funlen,maintidx
 						},
 					},
 				},
+				Autoscaler: nil,
 			},
 		},
 		Functions: &model.ConfigFunctions{
@@ -138,6 +139,7 @@ func commandExample(cCtx *cli.Context) error { //nolint:funlen,maintidx
 						},
 					},
 				},
+				Autoscaler: nil,
 			},
 			Redirections: &model.ConfigAuthRedirections{
 				ClientUrl: ptr("https://example.com"),
@@ -326,6 +328,7 @@ func commandExample(cCtx *cli.Context) error { //nolint:funlen,maintidx
 				Storage: &model.ConfigPostgresStorage{
 					Capacity: 20,
 				},
+				Autoscaler: nil,
 			},
 			Settings: &model.ConfigPostgresSettings{
 				Jit:                           ptr("off"),
@@ -380,6 +383,7 @@ func commandExample(cCtx *cli.Context) error { //nolint:funlen,maintidx
 				},
 				Networking: nil,
 				Replicas:   ptr(uint8(1)),
+				Autoscaler: nil,
 			},
 		},
 		Observability: &model.ConfigObservability{

--- a/cmd/run/config_example.go
+++ b/cmd/run/config_example.go
@@ -70,7 +70,8 @@ func commandConfigExample(cCtx *cli.Context) error { //nolint:funlen
 					Path:     "/var/lib/my-storage",
 				},
 			},
-			Replicas: 1,
+			Replicas:   1,
+			Autoscaler: nil,
 		},
 		HealthCheck: &model.ConfigHealthCheck{
 			Port:                8080,

--- a/dockercompose/compose.go
+++ b/dockercompose/compose.go
@@ -345,7 +345,7 @@ func functions( //nolint:funlen
 	}
 
 	return &Service{
-		Image:       "nhost/functions:1.1.0",
+		Image:       fmt.Sprintf("nhost/functions:%d-1.2.0", *cfg.GetFunctions().GetNode().Version),
 		DependsOn:   nil,
 		EntryPoint:  nil,
 		Command:     nil,

--- a/dockercompose/main_test.go
+++ b/dockercompose/main_test.go
@@ -35,6 +35,7 @@ func getConfig() *model.ConfigConfig { //nolint:maintidx
 				},
 				Replicas:   ptr(uint8(3)),
 				Networking: nil,
+				Autoscaler: nil,
 			},
 			Method: &model.ConfigAuthMethod{
 				Anonymous: &model.ConfigAuthMethodAnonymous{
@@ -241,6 +242,7 @@ func getConfig() *model.ConfigConfig { //nolint:maintidx
 				},
 				Replicas:   ptr(uint8(3)),
 				Networking: nil,
+				Autoscaler: nil,
 			},
 			AdminSecret: "adminSecret",
 			JwtSecrets: []*model.ConfigJWTSecret{
@@ -291,6 +293,7 @@ func getConfig() *model.ConfigConfig { //nolint:maintidx
 				Replicas:           ptr(uint8(1)),
 				Networking:         nil,
 				Storage:            nil,
+				Autoscaler:         nil,
 			},
 			Settings: nil,
 		},
@@ -319,6 +322,7 @@ func getConfig() *model.ConfigConfig { //nolint:maintidx
 				},
 				Replicas:   ptr(uint8(1)),
 				Networking: nil,
+				Autoscaler: nil,
 			},
 			Antivirus: &model.ConfigStorageAntivirus{
 				Server: ptr("tcp://run-clamav:3310"),

--- a/dockercompose/run_test.go
+++ b/dockercompose/run_test.go
@@ -71,7 +71,8 @@ func TestRun(t *testing.T) {
 								Path:     "/path/to/asd",
 							},
 						},
-						Replicas: 1,
+						Replicas:   1,
+						Autoscaler: nil,
 					},
 					HealthCheck: &model.ConfigHealthCheck{
 						Port:                80,

--- a/examples/myproject/functions/echo.ts
+++ b/examples/myproject/functions/echo.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express'
 import process from 'process'
 
 export default (req: Request, res: Response) => {
-    res.status(201).json(
+    res.status(200).json(
         {
             headers: req.headers,
             query: req.query,

--- a/examples/myproject/functions/echo.ts
+++ b/examples/myproject/functions/echo.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express'
 import process from 'process'
 
 export default (req: Request, res: Response) => {
-    res.status(200).json(
+    res.status(201).json(
         {
             headers: req.headers,
             query: req.query,

--- a/examples/myproject/nhost/nhost.toml
+++ b/examples/myproject/nhost/nhost.toml
@@ -23,7 +23,7 @@ liveQueriesMultiplexedRefetchInterval = 3000
 
 [functions]
 [functions.node]
-version = 18
+version = 20
 
 [auth]
 version = '0.30.0'

--- a/examples/myproject/nhost/nhost.toml
+++ b/examples/myproject/nhost/nhost.toml
@@ -23,7 +23,7 @@ liveQueriesMultiplexedRefetchInterval = 3000
 
 [functions]
 [functions.node]
-version = 20
+version = 18
 
 [auth]
 version = '0.30.0'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nhost/cli
 
-go 1.22.3
+go 1.22.4
 
 replace cuelang.org/go => cuelang.org/go v0.4.3
 
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-getter v1.7.4
-	github.com/nhost/be v0.0.0-20240602150839-1378b27df5bd
+	github.com/nhost/be v0.0.0-20240625131512-a8179f6db186
 	github.com/pelletier/go-toml/v2 v2.2.2
 	github.com/rs/cors/wrapper/gin v0.0.0-20240515105523-1562b1715b35
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -506,6 +506,8 @@ github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/nhost/be v0.0.0-20240602150839-1378b27df5bd h1:z+GKKHahUHh/QPApzgAmxBRKH9b1N/6kv1EBGm6Wx0U=
 github.com/nhost/be v0.0.0-20240602150839-1378b27df5bd/go.mod h1:Em0irE+nRN6LEbNyVRSlAVPgEZ01FsLv2Rz+7HkJLYc=
+github.com/nhost/be v0.0.0-20240625131512-a8179f6db186 h1:Lvh7Sj546Ss/e+w4ifAVwdNl3OqvoJz87VyQZfeJEH0=
+github.com/nhost/be v0.0.0-20240625131512-a8179f6db186/go.mod h1:EflwCYo5EwzcTdj2UvjmA2FFWYKaqYe4b2UuOcPGC8w=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
 github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=

--- a/nhostclient/graphql/models_gen.go
+++ b/nhostclient/graphql/models_gen.go
@@ -424,6 +424,18 @@ type ConfigAuthsessionaccessTokenCustomClaimsUpdateInput struct {
 	Value *string `json:"value,omitempty"`
 }
 
+type ConfigAutoscaler struct {
+	MaxReplicas uint32 `json:"maxReplicas"`
+}
+
+type ConfigAutoscalerInsertInput struct {
+	MaxReplicas uint32 `json:"maxReplicas"`
+}
+
+type ConfigAutoscalerUpdateInput struct {
+	MaxReplicas *uint32 `json:"maxReplicas,omitempty"`
+}
+
 type ConfigClaimMap struct {
 	Claim   string  `json:"claim"`
 	Default *string `json:"default,omitempty"`
@@ -719,6 +731,7 @@ type ConfigPostgres struct {
 }
 
 type ConfigPostgresResources struct {
+	Autoscaler         *ConfigAutoscaler       `json:"autoscaler,omitempty"`
 	Compute            *ConfigResourcesCompute `json:"compute,omitempty"`
 	EnablePublicAccess *bool                   `json:"enablePublicAccess,omitempty"`
 	Networking         *ConfigNetworking       `json:"networking,omitempty"`
@@ -727,6 +740,7 @@ type ConfigPostgresResources struct {
 }
 
 type ConfigPostgresResourcesUpdateInput struct {
+	Autoscaler         *ConfigAutoscalerUpdateInput       `json:"autoscaler,omitempty"`
 	Compute            *ConfigResourcesComputeUpdateInput `json:"compute,omitempty"`
 	EnablePublicAccess *bool                              `json:"enablePublicAccess,omitempty"`
 	Networking         *ConfigNetworkingUpdateInput       `json:"networking,omitempty"`
@@ -807,6 +821,7 @@ type ConfigProviderUpdateInput struct {
 }
 
 type ConfigResources struct {
+	Autoscaler *ConfigAutoscaler       `json:"autoscaler,omitempty"`
 	Compute    *ConfigResourcesCompute `json:"compute,omitempty"`
 	Networking *ConfigNetworking       `json:"networking,omitempty"`
 	Replicas   *uint32                 `json:"replicas,omitempty"`
@@ -823,6 +838,7 @@ type ConfigResourcesComputeUpdateInput struct {
 }
 
 type ConfigResourcesUpdateInput struct {
+	Autoscaler *ConfigAutoscalerUpdateInput       `json:"autoscaler,omitempty"`
 	Compute    *ConfigResourcesComputeUpdateInput `json:"compute,omitempty"`
 	Networking *ConfigNetworkingUpdateInput       `json:"networking,omitempty"`
 	Replicas   *uint32                            `json:"replicas,omitempty"`
@@ -897,15 +913,17 @@ type ConfigRunServicePortUpdateInput struct {
 }
 
 type ConfigRunServiceResources struct {
-	Compute  *ConfigComputeResources             `json:"compute"`
-	Replicas uint32                              `json:"replicas"`
-	Storage  []*ConfigRunServiceResourcesStorage `json:"storage,omitempty"`
+	Autoscaler *ConfigAutoscaler                   `json:"autoscaler,omitempty"`
+	Compute    *ConfigComputeResources             `json:"compute"`
+	Replicas   uint32                              `json:"replicas"`
+	Storage    []*ConfigRunServiceResourcesStorage `json:"storage,omitempty"`
 }
 
 type ConfigRunServiceResourcesInsertInput struct {
-	Compute  *ConfigComputeResourcesInsertInput             `json:"compute"`
-	Replicas uint32                                         `json:"replicas"`
-	Storage  []*ConfigRunServiceResourcesStorageInsertInput `json:"storage,omitempty"`
+	Autoscaler *ConfigAutoscalerInsertInput                   `json:"autoscaler,omitempty"`
+	Compute    *ConfigComputeResourcesInsertInput             `json:"compute"`
+	Replicas   uint32                                         `json:"replicas"`
+	Storage    []*ConfigRunServiceResourcesStorageInsertInput `json:"storage,omitempty"`
 }
 
 type ConfigRunServiceResourcesStorage struct {
@@ -927,9 +945,10 @@ type ConfigRunServiceResourcesStorageUpdateInput struct {
 }
 
 type ConfigRunServiceResourcesUpdateInput struct {
-	Compute  *ConfigComputeResourcesUpdateInput             `json:"compute,omitempty"`
-	Replicas *uint32                                        `json:"replicas,omitempty"`
-	Storage  []*ConfigRunServiceResourcesStorageUpdateInput `json:"storage,omitempty"`
+	Autoscaler *ConfigAutoscalerUpdateInput                   `json:"autoscaler,omitempty"`
+	Compute    *ConfigComputeResourcesUpdateInput             `json:"compute,omitempty"`
+	Replicas   *uint32                                        `json:"replicas,omitempty"`
+	Storage    []*ConfigRunServiceResourcesStorageUpdateInput `json:"storage,omitempty"`
 }
 
 type ConfigSms struct {

--- a/vendor/github.com/nhost/be/services/mimir/graph/m_replace_config_raw_json.go
+++ b/vendor/github.com/nhost/be/services/mimir/graph/m_replace_config_raw_json.go
@@ -1,0 +1,37 @@
+package graph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nhost/be/services/mimir/model"
+)
+
+func (r *mutationResolver) replaceConfigRawJSON(
+	ctx context.Context, appID string, rawJSON string,
+) (string, error) {
+	var config model.ConfigConfigInsertInput
+
+	dec := json.NewDecoder(strings.NewReader(rawJSON))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&config); err != nil {
+		return "", fmt.Errorf("failed to decode raw JSON: %w", err)
+	}
+
+	cfg, err := r.replaceConfig(ctx, appID, config)
+	if err != nil {
+		return "", err
+	}
+	if cfg == nil {
+		return "{}", nil
+	}
+
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return "{}", fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	return string(b), nil
+}

--- a/vendor/github.com/nhost/be/services/mimir/graph/schema.resolvers.go
+++ b/vendor/github.com/nhost/be/services/mimir/graph/schema.resolvers.go
@@ -21,6 +21,11 @@ func (r *mutationResolver) ReplaceConfig(ctx context.Context, appID string, conf
 	return r.replaceConfig(ctx, appID, config)
 }
 
+// UpdateConfigRawJSON is the resolver for the updateConfigRawJSON field.
+func (r *mutationResolver) ReplaceConfigRawJSON(ctx context.Context, appID string, rawJSON string) (string, error) {
+	return r.replaceConfigRawJSON(ctx, appID, rawJSON)
+}
+
 // InsertConfig is the resolver for the insertConfig field.
 func (r *mutationResolver) InsertConfig(ctx context.Context, appID string, config model.ConfigConfigInsertInput, systemConfig model.ConfigSystemConfigInsertInput, secrets []*model.ConfigEnvironmentVariableInsertInput) (*model.ConfigInsertConfigResponse, error) {
 	return r.insertConfig(ctx, appID, config, systemConfig, secrets)

--- a/vendor/github.com/nhost/be/services/mimir/model/cuegraph_gen.go
+++ b/vendor/github.com/nhost/be/services/mimir/model/cuegraph_gen.go
@@ -8585,6 +8585,138 @@ func (exp *ConfigAuthsessionaccessTokenCustomClaimsComparisonExp) Matches(o *Con
 	return true
 }
 
+type ConfigAutoscaler struct {
+	MaxReplicas uint8 `json:"maxReplicas" toml:"maxReplicas"`
+}
+
+func (o *ConfigAutoscaler) MarshalJSON() ([]byte, error) {
+	m := make(map[string]any)
+	m["maxReplicas"] = o.MaxReplicas
+	return json.Marshal(m)
+}
+
+func (o *ConfigAutoscaler) GetMaxReplicas() uint8 {
+	if o == nil {
+		o = &ConfigAutoscaler{}
+	}
+	return o.MaxReplicas
+}
+
+type ConfigAutoscalerUpdateInput struct {
+	MaxReplicas      *uint8 `json:"maxReplicas,omitempty" toml:"maxReplicas,omitempty"`
+	IsSetMaxReplicas bool   `json:"-"`
+}
+
+func (o *ConfigAutoscalerUpdateInput) UnmarshalGQL(v interface{}) error {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return fmt.Errorf("must be map[string]interface{}, got %T", v)
+	}
+	if v, ok := m["maxReplicas"]; ok {
+		if v == nil {
+			o.MaxReplicas = nil
+		} else {
+			// clearly a not very efficient shortcut
+			b, err := json.Marshal(v)
+			if err != nil {
+				return err
+			}
+			var x uint8
+			if err := json.Unmarshal(b, &x); err != nil {
+				return err
+			}
+			o.MaxReplicas = &x
+		}
+		o.IsSetMaxReplicas = true
+	}
+
+	return nil
+}
+
+func (o *ConfigAutoscalerUpdateInput) MarshalGQL(w io.Writer) {
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(o); err != nil {
+		panic(err)
+	}
+}
+
+func (o *ConfigAutoscalerUpdateInput) GetMaxReplicas() *uint8 {
+	if o == nil {
+		o = &ConfigAutoscalerUpdateInput{}
+	}
+	return o.MaxReplicas
+}
+
+func (s *ConfigAutoscaler) Update(v *ConfigAutoscalerUpdateInput) {
+	if v == nil {
+		return
+	}
+	if v.IsSetMaxReplicas || v.MaxReplicas != nil {
+		if v.MaxReplicas != nil {
+			s.MaxReplicas = *v.MaxReplicas
+		}
+	}
+}
+
+type ConfigAutoscalerInsertInput struct {
+	MaxReplicas uint8 `json:"maxReplicas,omitempty" toml:"maxReplicas,omitempty"`
+}
+
+func (o *ConfigAutoscalerInsertInput) GetMaxReplicas() uint8 {
+	if o == nil {
+		o = &ConfigAutoscalerInsertInput{}
+	}
+	return o.MaxReplicas
+}
+
+func (s *ConfigAutoscaler) Insert(v *ConfigAutoscalerInsertInput) {
+	s.MaxReplicas = v.MaxReplicas
+}
+
+func (s *ConfigAutoscaler) Clone() *ConfigAutoscaler {
+	if s == nil {
+		return nil
+	}
+
+	v := &ConfigAutoscaler{}
+	v.MaxReplicas = s.MaxReplicas
+	return v
+}
+
+type ConfigAutoscalerComparisonExp struct {
+	And         []*ConfigAutoscalerComparisonExp `json:"_and,omitempty"`
+	Not         *ConfigAutoscalerComparisonExp   `json:"_not,omitempty"`
+	Or          []*ConfigAutoscalerComparisonExp `json:"_or,omitempty"`
+	MaxReplicas *ConfigUint8ComparisonExp        `json:"maxReplicas,omitempty"`
+}
+
+func (exp *ConfigAutoscalerComparisonExp) Matches(o *ConfigAutoscaler) bool {
+	if exp == nil {
+		return true
+	}
+
+	if o == nil {
+		o = &ConfigAutoscaler{}
+	}
+	if !exp.MaxReplicas.Matches(o.MaxReplicas) {
+		return false
+	}
+
+	if exp.And != nil && !all(exp.And, o) {
+		return false
+	}
+
+	if exp.Or != nil && !or(exp.Or, o) {
+		return false
+	}
+
+	if exp.Not != nil && exp.Not.Matches(o) {
+		return false
+	}
+
+	return true
+}
+
 type ConfigClaimMap struct {
 	Claim string `json:"claim" toml:"claim"`
 
@@ -14756,6 +14888,8 @@ type ConfigPostgresResources struct {
 	// Number of replicas for a service
 	Replicas *uint8 `json:"replicas" toml:"replicas"`
 
+	Autoscaler *ConfigAutoscaler `json:"autoscaler,omitempty" toml:"autoscaler,omitempty"`
+
 	Networking *ConfigNetworking `json:"networking,omitempty" toml:"networking,omitempty"`
 
 	Storage *ConfigPostgresStorage `json:"storage,omitempty" toml:"storage,omitempty"`
@@ -14770,6 +14904,9 @@ func (o *ConfigPostgresResources) MarshalJSON() ([]byte, error) {
 	}
 	if o.Replicas != nil {
 		m["replicas"] = o.Replicas
+	}
+	if o.Autoscaler != nil {
+		m["autoscaler"] = o.Autoscaler
 	}
 	if o.Networking != nil {
 		m["networking"] = o.Networking
@@ -14795,6 +14932,13 @@ func (o *ConfigPostgresResources) GetReplicas() *uint8 {
 		o = &ConfigPostgresResources{}
 	}
 	return o.Replicas
+}
+
+func (o *ConfigPostgresResources) GetAutoscaler() *ConfigAutoscaler {
+	if o == nil {
+		return nil
+	}
+	return o.Autoscaler
 }
 
 func (o *ConfigPostgresResources) GetNetworking() *ConfigNetworking {
@@ -14823,6 +14967,8 @@ type ConfigPostgresResourcesUpdateInput struct {
 	IsSetCompute            bool                               `json:"-"`
 	Replicas                *uint8                             `json:"replicas,omitempty" toml:"replicas,omitempty"`
 	IsSetReplicas           bool                               `json:"-"`
+	Autoscaler              *ConfigAutoscalerUpdateInput       `json:"autoscaler,omitempty" toml:"autoscaler,omitempty"`
+	IsSetAutoscaler         bool                               `json:"-"`
 	Networking              *ConfigNetworkingUpdateInput       `json:"networking,omitempty" toml:"networking,omitempty"`
 	IsSetNetworking         bool                               `json:"-"`
 	Storage                 *ConfigPostgresStorageUpdateInput  `json:"storage,omitempty" toml:"storage,omitempty"`
@@ -14862,6 +15008,16 @@ func (o *ConfigPostgresResourcesUpdateInput) UnmarshalGQL(v interface{}) error {
 			o.Replicas = &x
 		}
 		o.IsSetReplicas = true
+	}
+	if x, ok := m["autoscaler"]; ok {
+		if x != nil {
+			t := &ConfigAutoscalerUpdateInput{}
+			if err := t.UnmarshalGQL(x); err != nil {
+				return err
+			}
+			o.Autoscaler = t
+		}
+		o.IsSetAutoscaler = true
 	}
 	if x, ok := m["networking"]; ok {
 		if x != nil {
@@ -14925,6 +15081,13 @@ func (o *ConfigPostgresResourcesUpdateInput) GetReplicas() *uint8 {
 	return o.Replicas
 }
 
+func (o *ConfigPostgresResourcesUpdateInput) GetAutoscaler() *ConfigAutoscalerUpdateInput {
+	if o == nil {
+		return nil
+	}
+	return o.Autoscaler
+}
+
 func (o *ConfigPostgresResourcesUpdateInput) GetNetworking() *ConfigNetworkingUpdateInput {
 	if o == nil {
 		return nil
@@ -14963,6 +15126,16 @@ func (s *ConfigPostgresResources) Update(v *ConfigPostgresResourcesUpdateInput) 
 	if v.IsSetReplicas || v.Replicas != nil {
 		s.Replicas = v.Replicas
 	}
+	if v.IsSetAutoscaler || v.Autoscaler != nil {
+		if v.Autoscaler == nil {
+			s.Autoscaler = nil
+		} else {
+			if s.Autoscaler == nil {
+				s.Autoscaler = &ConfigAutoscaler{}
+			}
+			s.Autoscaler.Update(v.Autoscaler)
+		}
+	}
 	if v.IsSetNetworking || v.Networking != nil {
 		if v.Networking == nil {
 			s.Networking = nil
@@ -14991,6 +15164,7 @@ func (s *ConfigPostgresResources) Update(v *ConfigPostgresResourcesUpdateInput) 
 type ConfigPostgresResourcesInsertInput struct {
 	Compute            *ConfigResourcesComputeInsertInput `json:"compute,omitempty" toml:"compute,omitempty"`
 	Replicas           *uint8                             `json:"replicas,omitempty" toml:"replicas,omitempty"`
+	Autoscaler         *ConfigAutoscalerInsertInput       `json:"autoscaler,omitempty" toml:"autoscaler,omitempty"`
 	Networking         *ConfigNetworkingInsertInput       `json:"networking,omitempty" toml:"networking,omitempty"`
 	Storage            *ConfigPostgresStorageInsertInput  `json:"storage,omitempty" toml:"storage,omitempty"`
 	EnablePublicAccess *bool                              `json:"enablePublicAccess,omitempty" toml:"enablePublicAccess,omitempty"`
@@ -15008,6 +15182,13 @@ func (o *ConfigPostgresResourcesInsertInput) GetReplicas() *uint8 {
 		o = &ConfigPostgresResourcesInsertInput{}
 	}
 	return o.Replicas
+}
+
+func (o *ConfigPostgresResourcesInsertInput) GetAutoscaler() *ConfigAutoscalerInsertInput {
+	if o == nil {
+		return nil
+	}
+	return o.Autoscaler
 }
 
 func (o *ConfigPostgresResourcesInsertInput) GetNetworking() *ConfigNetworkingInsertInput {
@@ -15039,6 +15220,12 @@ func (s *ConfigPostgresResources) Insert(v *ConfigPostgresResourcesInsertInput) 
 		s.Compute.Insert(v.Compute)
 	}
 	s.Replicas = v.Replicas
+	if v.Autoscaler != nil {
+		if s.Autoscaler == nil {
+			s.Autoscaler = &ConfigAutoscaler{}
+		}
+		s.Autoscaler.Insert(v.Autoscaler)
+	}
 	if v.Networking != nil {
 		if s.Networking == nil {
 			s.Networking = &ConfigNetworking{}
@@ -15062,6 +15249,7 @@ func (s *ConfigPostgresResources) Clone() *ConfigPostgresResources {
 	v := &ConfigPostgresResources{}
 	v.Compute = s.Compute.Clone()
 	v.Replicas = s.Replicas
+	v.Autoscaler = s.Autoscaler.Clone()
 	v.Networking = s.Networking.Clone()
 	v.Storage = s.Storage.Clone()
 	v.EnablePublicAccess = s.EnablePublicAccess
@@ -15074,6 +15262,7 @@ type ConfigPostgresResourcesComparisonExp struct {
 	Or                 []*ConfigPostgresResourcesComparisonExp `json:"_or,omitempty"`
 	Compute            *ConfigResourcesComputeComparisonExp    `json:"compute,omitempty"`
 	Replicas           *ConfigUint8ComparisonExp               `json:"replicas,omitempty"`
+	Autoscaler         *ConfigAutoscalerComparisonExp          `json:"autoscaler,omitempty"`
 	Networking         *ConfigNetworkingComparisonExp          `json:"networking,omitempty"`
 	Storage            *ConfigPostgresStorageComparisonExp     `json:"storage,omitempty"`
 	EnablePublicAccess *ConfigBooleanComparisonExp             `json:"enablePublicAccess,omitempty"`
@@ -15087,6 +15276,7 @@ func (exp *ConfigPostgresResourcesComparisonExp) Matches(o *ConfigPostgresResour
 	if o == nil {
 		o = &ConfigPostgresResources{
 			Compute:    &ConfigResourcesCompute{},
+			Autoscaler: &ConfigAutoscaler{},
 			Networking: &ConfigNetworking{},
 			Storage:    &ConfigPostgresStorage{},
 		}
@@ -15095,6 +15285,9 @@ func (exp *ConfigPostgresResourcesComparisonExp) Matches(o *ConfigPostgresResour
 		return false
 	}
 	if o.Replicas != nil && !exp.Replicas.Matches(*o.Replicas) {
+		return false
+	}
+	if !exp.Autoscaler.Matches(o.Autoscaler) {
 		return false
 	}
 	if !exp.Networking.Matches(o.Networking) {
@@ -16693,6 +16886,8 @@ type ConfigResources struct {
 	// Number of replicas for a service
 	Replicas *uint8 `json:"replicas" toml:"replicas"`
 
+	Autoscaler *ConfigAutoscaler `json:"autoscaler,omitempty" toml:"autoscaler,omitempty"`
+
 	Networking *ConfigNetworking `json:"networking,omitempty" toml:"networking,omitempty"`
 }
 
@@ -16703,6 +16898,9 @@ func (o *ConfigResources) MarshalJSON() ([]byte, error) {
 	}
 	if o.Replicas != nil {
 		m["replicas"] = o.Replicas
+	}
+	if o.Autoscaler != nil {
+		m["autoscaler"] = o.Autoscaler
 	}
 	if o.Networking != nil {
 		m["networking"] = o.Networking
@@ -16724,6 +16922,13 @@ func (o *ConfigResources) GetReplicas() *uint8 {
 	return o.Replicas
 }
 
+func (o *ConfigResources) GetAutoscaler() *ConfigAutoscaler {
+	if o == nil {
+		return nil
+	}
+	return o.Autoscaler
+}
+
 func (o *ConfigResources) GetNetworking() *ConfigNetworking {
 	if o == nil {
 		return nil
@@ -16736,6 +16941,8 @@ type ConfigResourcesUpdateInput struct {
 	IsSetCompute    bool                               `json:"-"`
 	Replicas        *uint8                             `json:"replicas,omitempty" toml:"replicas,omitempty"`
 	IsSetReplicas   bool                               `json:"-"`
+	Autoscaler      *ConfigAutoscalerUpdateInput       `json:"autoscaler,omitempty" toml:"autoscaler,omitempty"`
+	IsSetAutoscaler bool                               `json:"-"`
 	Networking      *ConfigNetworkingUpdateInput       `json:"networking,omitempty" toml:"networking,omitempty"`
 	IsSetNetworking bool                               `json:"-"`
 }
@@ -16772,6 +16979,16 @@ func (o *ConfigResourcesUpdateInput) UnmarshalGQL(v interface{}) error {
 		}
 		o.IsSetReplicas = true
 	}
+	if x, ok := m["autoscaler"]; ok {
+		if x != nil {
+			t := &ConfigAutoscalerUpdateInput{}
+			if err := t.UnmarshalGQL(x); err != nil {
+				return err
+			}
+			o.Autoscaler = t
+		}
+		o.IsSetAutoscaler = true
+	}
 	if x, ok := m["networking"]; ok {
 		if x != nil {
 			t := &ConfigNetworkingUpdateInput{}
@@ -16807,6 +17024,13 @@ func (o *ConfigResourcesUpdateInput) GetReplicas() *uint8 {
 	return o.Replicas
 }
 
+func (o *ConfigResourcesUpdateInput) GetAutoscaler() *ConfigAutoscalerUpdateInput {
+	if o == nil {
+		return nil
+	}
+	return o.Autoscaler
+}
+
 func (o *ConfigResourcesUpdateInput) GetNetworking() *ConfigNetworkingUpdateInput {
 	if o == nil {
 		return nil
@@ -16831,6 +17055,16 @@ func (s *ConfigResources) Update(v *ConfigResourcesUpdateInput) {
 	if v.IsSetReplicas || v.Replicas != nil {
 		s.Replicas = v.Replicas
 	}
+	if v.IsSetAutoscaler || v.Autoscaler != nil {
+		if v.Autoscaler == nil {
+			s.Autoscaler = nil
+		} else {
+			if s.Autoscaler == nil {
+				s.Autoscaler = &ConfigAutoscaler{}
+			}
+			s.Autoscaler.Update(v.Autoscaler)
+		}
+	}
 	if v.IsSetNetworking || v.Networking != nil {
 		if v.Networking == nil {
 			s.Networking = nil
@@ -16846,6 +17080,7 @@ func (s *ConfigResources) Update(v *ConfigResourcesUpdateInput) {
 type ConfigResourcesInsertInput struct {
 	Compute    *ConfigResourcesComputeInsertInput `json:"compute,omitempty" toml:"compute,omitempty"`
 	Replicas   *uint8                             `json:"replicas,omitempty" toml:"replicas,omitempty"`
+	Autoscaler *ConfigAutoscalerInsertInput       `json:"autoscaler,omitempty" toml:"autoscaler,omitempty"`
 	Networking *ConfigNetworkingInsertInput       `json:"networking,omitempty" toml:"networking,omitempty"`
 }
 
@@ -16863,6 +17098,13 @@ func (o *ConfigResourcesInsertInput) GetReplicas() *uint8 {
 	return o.Replicas
 }
 
+func (o *ConfigResourcesInsertInput) GetAutoscaler() *ConfigAutoscalerInsertInput {
+	if o == nil {
+		return nil
+	}
+	return o.Autoscaler
+}
+
 func (o *ConfigResourcesInsertInput) GetNetworking() *ConfigNetworkingInsertInput {
 	if o == nil {
 		return nil
@@ -16878,6 +17120,12 @@ func (s *ConfigResources) Insert(v *ConfigResourcesInsertInput) {
 		s.Compute.Insert(v.Compute)
 	}
 	s.Replicas = v.Replicas
+	if v.Autoscaler != nil {
+		if s.Autoscaler == nil {
+			s.Autoscaler = &ConfigAutoscaler{}
+		}
+		s.Autoscaler.Insert(v.Autoscaler)
+	}
 	if v.Networking != nil {
 		if s.Networking == nil {
 			s.Networking = &ConfigNetworking{}
@@ -16894,6 +17142,7 @@ func (s *ConfigResources) Clone() *ConfigResources {
 	v := &ConfigResources{}
 	v.Compute = s.Compute.Clone()
 	v.Replicas = s.Replicas
+	v.Autoscaler = s.Autoscaler.Clone()
 	v.Networking = s.Networking.Clone()
 	return v
 }
@@ -16904,6 +17153,7 @@ type ConfigResourcesComparisonExp struct {
 	Or         []*ConfigResourcesComparisonExp      `json:"_or,omitempty"`
 	Compute    *ConfigResourcesComputeComparisonExp `json:"compute,omitempty"`
 	Replicas   *ConfigUint8ComparisonExp            `json:"replicas,omitempty"`
+	Autoscaler *ConfigAutoscalerComparisonExp       `json:"autoscaler,omitempty"`
 	Networking *ConfigNetworkingComparisonExp       `json:"networking,omitempty"`
 }
 
@@ -16915,6 +17165,7 @@ func (exp *ConfigResourcesComparisonExp) Matches(o *ConfigResources) bool {
 	if o == nil {
 		o = &ConfigResources{
 			Compute:    &ConfigResourcesCompute{},
+			Autoscaler: &ConfigAutoscaler{},
 			Networking: &ConfigNetworking{},
 		}
 	}
@@ -16922,6 +17173,9 @@ func (exp *ConfigResourcesComparisonExp) Matches(o *ConfigResources) bool {
 		return false
 	}
 	if o.Replicas != nil && !exp.Replicas.Matches(*o.Replicas) {
+		return false
+	}
+	if !exp.Autoscaler.Matches(o.Autoscaler) {
 		return false
 	}
 	if !exp.Networking.Matches(o.Networking) {
@@ -18202,6 +18456,8 @@ type ConfigRunServiceResources struct {
 	Storage []*ConfigRunServiceResourcesStorage `json:"storage,omitempty" toml:"storage,omitempty"`
 	// Number of replicas for a service
 	Replicas uint8 `json:"replicas" toml:"replicas"`
+
+	Autoscaler *ConfigAutoscaler `json:"autoscaler,omitempty" toml:"autoscaler,omitempty"`
 }
 
 func (o *ConfigRunServiceResources) MarshalJSON() ([]byte, error) {
@@ -18213,6 +18469,9 @@ func (o *ConfigRunServiceResources) MarshalJSON() ([]byte, error) {
 		m["storage"] = o.Storage
 	}
 	m["replicas"] = o.Replicas
+	if o.Autoscaler != nil {
+		m["autoscaler"] = o.Autoscaler
+	}
 	return json.Marshal(m)
 }
 
@@ -18237,13 +18496,22 @@ func (o *ConfigRunServiceResources) GetReplicas() uint8 {
 	return o.Replicas
 }
 
+func (o *ConfigRunServiceResources) GetAutoscaler() *ConfigAutoscaler {
+	if o == nil {
+		return nil
+	}
+	return o.Autoscaler
+}
+
 type ConfigRunServiceResourcesUpdateInput struct {
-	Compute       *ConfigComputeResourcesUpdateInput             `json:"compute,omitempty" toml:"compute,omitempty"`
-	IsSetCompute  bool                                           `json:"-"`
-	Storage       []*ConfigRunServiceResourcesStorageUpdateInput `json:"storage,omitempty" toml:"storage,omitempty"`
-	IsSetStorage  bool                                           `json:"-"`
-	Replicas      *uint8                                         `json:"replicas,omitempty" toml:"replicas,omitempty"`
-	IsSetReplicas bool                                           `json:"-"`
+	Compute         *ConfigComputeResourcesUpdateInput             `json:"compute,omitempty" toml:"compute,omitempty"`
+	IsSetCompute    bool                                           `json:"-"`
+	Storage         []*ConfigRunServiceResourcesStorageUpdateInput `json:"storage,omitempty" toml:"storage,omitempty"`
+	IsSetStorage    bool                                           `json:"-"`
+	Replicas        *uint8                                         `json:"replicas,omitempty" toml:"replicas,omitempty"`
+	IsSetReplicas   bool                                           `json:"-"`
+	Autoscaler      *ConfigAutoscalerUpdateInput                   `json:"autoscaler,omitempty" toml:"autoscaler,omitempty"`
+	IsSetAutoscaler bool                                           `json:"-"`
 }
 
 func (o *ConfigRunServiceResourcesUpdateInput) UnmarshalGQL(v interface{}) error {
@@ -18297,6 +18565,16 @@ func (o *ConfigRunServiceResourcesUpdateInput) UnmarshalGQL(v interface{}) error
 		}
 		o.IsSetReplicas = true
 	}
+	if x, ok := m["autoscaler"]; ok {
+		if x != nil {
+			t := &ConfigAutoscalerUpdateInput{}
+			if err := t.UnmarshalGQL(x); err != nil {
+				return err
+			}
+			o.Autoscaler = t
+		}
+		o.IsSetAutoscaler = true
+	}
 
 	return nil
 }
@@ -18327,6 +18605,13 @@ func (o *ConfigRunServiceResourcesUpdateInput) GetReplicas() *uint8 {
 		o = &ConfigRunServiceResourcesUpdateInput{}
 	}
 	return o.Replicas
+}
+
+func (o *ConfigRunServiceResourcesUpdateInput) GetAutoscaler() *ConfigAutoscalerUpdateInput {
+	if o == nil {
+		return nil
+	}
+	return o.Autoscaler
 }
 
 func (s *ConfigRunServiceResources) Update(v *ConfigRunServiceResourcesUpdateInput) {
@@ -18360,12 +18645,23 @@ func (s *ConfigRunServiceResources) Update(v *ConfigRunServiceResourcesUpdateInp
 			s.Replicas = *v.Replicas
 		}
 	}
+	if v.IsSetAutoscaler || v.Autoscaler != nil {
+		if v.Autoscaler == nil {
+			s.Autoscaler = nil
+		} else {
+			if s.Autoscaler == nil {
+				s.Autoscaler = &ConfigAutoscaler{}
+			}
+			s.Autoscaler.Update(v.Autoscaler)
+		}
+	}
 }
 
 type ConfigRunServiceResourcesInsertInput struct {
-	Compute  *ConfigComputeResourcesInsertInput             `json:"compute,omitempty" toml:"compute,omitempty"`
-	Storage  []*ConfigRunServiceResourcesStorageInsertInput `json:"storage,omitempty" toml:"storage,omitempty"`
-	Replicas uint8                                          `json:"replicas,omitempty" toml:"replicas,omitempty"`
+	Compute    *ConfigComputeResourcesInsertInput             `json:"compute,omitempty" toml:"compute,omitempty"`
+	Storage    []*ConfigRunServiceResourcesStorageInsertInput `json:"storage,omitempty" toml:"storage,omitempty"`
+	Replicas   uint8                                          `json:"replicas,omitempty" toml:"replicas,omitempty"`
+	Autoscaler *ConfigAutoscalerInsertInput                   `json:"autoscaler,omitempty" toml:"autoscaler,omitempty"`
 }
 
 func (o *ConfigRunServiceResourcesInsertInput) GetCompute() *ConfigComputeResourcesInsertInput {
@@ -18389,6 +18685,13 @@ func (o *ConfigRunServiceResourcesInsertInput) GetReplicas() uint8 {
 	return o.Replicas
 }
 
+func (o *ConfigRunServiceResourcesInsertInput) GetAutoscaler() *ConfigAutoscalerInsertInput {
+	if o == nil {
+		return nil
+	}
+	return o.Autoscaler
+}
+
 func (s *ConfigRunServiceResources) Insert(v *ConfigRunServiceResourcesInsertInput) {
 	if v.Compute != nil {
 		if s.Compute == nil {
@@ -18405,6 +18708,12 @@ func (s *ConfigRunServiceResources) Insert(v *ConfigRunServiceResourcesInsertInp
 		}
 	}
 	s.Replicas = v.Replicas
+	if v.Autoscaler != nil {
+		if s.Autoscaler == nil {
+			s.Autoscaler = &ConfigAutoscaler{}
+		}
+		s.Autoscaler.Insert(v.Autoscaler)
+	}
 }
 
 func (s *ConfigRunServiceResources) Clone() *ConfigRunServiceResources {
@@ -18421,16 +18730,18 @@ func (s *ConfigRunServiceResources) Clone() *ConfigRunServiceResources {
 		}
 	}
 	v.Replicas = s.Replicas
+	v.Autoscaler = s.Autoscaler.Clone()
 	return v
 }
 
 type ConfigRunServiceResourcesComparisonExp struct {
-	And      []*ConfigRunServiceResourcesComparisonExp      `json:"_and,omitempty"`
-	Not      *ConfigRunServiceResourcesComparisonExp        `json:"_not,omitempty"`
-	Or       []*ConfigRunServiceResourcesComparisonExp      `json:"_or,omitempty"`
-	Compute  *ConfigComputeResourcesComparisonExp           `json:"compute,omitempty"`
-	Storage  *ConfigRunServiceResourcesStorageComparisonExp `json:"storage,omitempty"`
-	Replicas *ConfigUint8ComparisonExp                      `json:"replicas,omitempty"`
+	And        []*ConfigRunServiceResourcesComparisonExp      `json:"_and,omitempty"`
+	Not        *ConfigRunServiceResourcesComparisonExp        `json:"_not,omitempty"`
+	Or         []*ConfigRunServiceResourcesComparisonExp      `json:"_or,omitempty"`
+	Compute    *ConfigComputeResourcesComparisonExp           `json:"compute,omitempty"`
+	Storage    *ConfigRunServiceResourcesStorageComparisonExp `json:"storage,omitempty"`
+	Replicas   *ConfigUint8ComparisonExp                      `json:"replicas,omitempty"`
+	Autoscaler *ConfigAutoscalerComparisonExp                 `json:"autoscaler,omitempty"`
 }
 
 func (exp *ConfigRunServiceResourcesComparisonExp) Matches(o *ConfigRunServiceResources) bool {
@@ -18440,8 +18751,9 @@ func (exp *ConfigRunServiceResourcesComparisonExp) Matches(o *ConfigRunServiceRe
 
 	if o == nil {
 		o = &ConfigRunServiceResources{
-			Compute: &ConfigComputeResources{},
-			Storage: []*ConfigRunServiceResourcesStorage{},
+			Compute:    &ConfigComputeResources{},
+			Storage:    []*ConfigRunServiceResourcesStorage{},
+			Autoscaler: &ConfigAutoscaler{},
 		}
 	}
 	if !exp.Compute.Matches(o.Compute) {
@@ -18460,6 +18772,9 @@ func (exp *ConfigRunServiceResourcesComparisonExp) Matches(o *ConfigRunServiceRe
 		}
 	}
 	if !exp.Replicas.Matches(o.Replicas) {
+		return false
+	}
+	if !exp.Autoscaler.Matches(o.Autoscaler) {
 		return false
 	}
 

--- a/vendor/github.com/nhost/be/services/mimir/schema/schema.graphqls
+++ b/vendor/github.com/nhost/be/services/mimir/schema/schema.graphqls
@@ -88,6 +88,10 @@ type Mutation {
         appID: uuid! @hasAppVisibility,
         config: ConfigConfigInsertInput!,
     ): ConfigConfig!
+    replaceConfigRawJSON(
+        appID: uuid! @hasAppVisibility,
+        rawJSON: String!,
+    ):String!
     insertConfig(
         appID: uuid! @hasAppVisibility,
         config: ConfigConfigInsertInput!,

--- a/vendor/github.com/nhost/be/services/mimir/schema/schema_gen.graphqls
+++ b/vendor/github.com/nhost/be/services/mimir/schema/schema_gen.graphqls
@@ -1396,6 +1396,31 @@ input ConfigAuthsessionaccessTokenCustomClaimsComparisonExp {
 """
 
 """
+type ConfigAutoscaler {
+    """
+
+    """
+    maxReplicas: ConfigUint8!
+}
+
+input ConfigAutoscalerUpdateInput {
+    maxReplicas: ConfigUint8
+}
+
+input ConfigAutoscalerInsertInput {
+    maxReplicas: ConfigUint8!
+}
+
+input ConfigAutoscalerComparisonExp {
+    _and: [ConfigAutoscalerComparisonExp!]
+    _not: ConfigAutoscalerComparisonExp
+    _or: [ConfigAutoscalerComparisonExp!]
+    maxReplicas: ConfigUint8ComparisonExp
+}
+
+"""
+
+"""
 type ConfigClaimMap {
     """
 
@@ -2359,6 +2384,10 @@ type ConfigPostgresResources {
     """
 
     """
+    autoscaler: ConfigAutoscaler
+    """
+
+    """
     networking: ConfigNetworking
     """
 
@@ -2373,6 +2402,7 @@ type ConfigPostgresResources {
 input ConfigPostgresResourcesUpdateInput {
     compute: ConfigResourcesComputeUpdateInput
     replicas: ConfigUint8
+    autoscaler: ConfigAutoscalerUpdateInput
     networking: ConfigNetworkingUpdateInput
     storage: ConfigPostgresStorageUpdateInput
     enablePublicAccess: Boolean
@@ -2381,6 +2411,7 @@ input ConfigPostgresResourcesUpdateInput {
 input ConfigPostgresResourcesInsertInput {
     compute: ConfigResourcesComputeInsertInput
     replicas: ConfigUint8
+    autoscaler: ConfigAutoscalerInsertInput
     networking: ConfigNetworkingInsertInput
     storage: ConfigPostgresStorageInsertInput
     enablePublicAccess: Boolean
@@ -2392,6 +2423,7 @@ input ConfigPostgresResourcesComparisonExp {
     _or: [ConfigPostgresResourcesComparisonExp!]
     compute: ConfigResourcesComputeComparisonExp
     replicas: ConfigUint8ComparisonExp
+    autoscaler: ConfigAutoscalerComparisonExp
     networking: ConfigNetworkingComparisonExp
     storage: ConfigPostgresStorageComparisonExp
     enablePublicAccess: ConfigBooleanComparisonExp
@@ -2634,18 +2666,24 @@ type ConfigResources {
     """
 
     """
+    autoscaler: ConfigAutoscaler
+    """
+
+    """
     networking: ConfigNetworking
 }
 
 input ConfigResourcesUpdateInput {
     compute: ConfigResourcesComputeUpdateInput
     replicas: ConfigUint8
+    autoscaler: ConfigAutoscalerUpdateInput
     networking: ConfigNetworkingUpdateInput
 }
 
 input ConfigResourcesInsertInput {
     compute: ConfigResourcesComputeInsertInput
     replicas: ConfigUint8
+    autoscaler: ConfigAutoscalerInsertInput
     networking: ConfigNetworkingInsertInput
 }
 
@@ -2655,6 +2693,7 @@ input ConfigResourcesComparisonExp {
     _or: [ConfigResourcesComparisonExp!]
     compute: ConfigResourcesComputeComparisonExp
     replicas: ConfigUint8ComparisonExp
+    autoscaler: ConfigAutoscalerComparisonExp
     networking: ConfigNetworkingComparisonExp
 }
 
@@ -2853,18 +2892,24 @@ type ConfigRunServiceResources {
     Number of replicas for a service
     """
     replicas: ConfigUint8!
+    """
+
+    """
+    autoscaler: ConfigAutoscaler
 }
 
 input ConfigRunServiceResourcesUpdateInput {
     compute: ConfigComputeResourcesUpdateInput
         storage: [ConfigRunServiceResourcesStorageUpdateInput!]
     replicas: ConfigUint8
+    autoscaler: ConfigAutoscalerUpdateInput
 }
 
 input ConfigRunServiceResourcesInsertInput {
     compute: ConfigComputeResourcesInsertInput!
         storage: [ConfigRunServiceResourcesStorageInsertInput!]
     replicas: ConfigUint8!
+    autoscaler: ConfigAutoscalerInsertInput
 }
 
 input ConfigRunServiceResourcesComparisonExp {
@@ -2874,6 +2919,7 @@ input ConfigRunServiceResourcesComparisonExp {
     compute: ConfigComputeResourcesComparisonExp
     storage: ConfigRunServiceResourcesStorageComparisonExp
     replicas: ConfigUint8ComparisonExp
+    autoscaler: ConfigAutoscalerComparisonExp
 }
 
 """

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -530,8 +530,8 @@ github.com/mpvl/unique
 # github.com/muesli/termenv v0.15.2
 ## explicit; go 1.17
 github.com/muesli/termenv
-# github.com/nhost/be v0.0.0-20240602150839-1378b27df5bd
-## explicit; go 1.22.3
+# github.com/nhost/be v0.0.0-20240625131512-a8179f6db186
+## explicit; go 1.22.4
 github.com/nhost/be/lib/graphql
 github.com/nhost/be/lib/graphql/context
 github.com/nhost/be/lib/graphql/handler


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `Autoscaler` field with `nil` value to various configurations in multiple files.
- Updated Docker Compose functions to use a dynamic image version format that includes the Node.js version.
- Updated Node.js version from 18 to 20 in the example project configuration.
- Updated Go version from 1.22.3 to 1.22.4 and updated `github.com/nhost/be` dependency version in `go.mod`.
- Updated checksums for dependencies in `go.sum`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>example.go</strong><dd><code>Add `Autoscaler` field to configurations in example command</code></dd></summary>
<hr>
      
cmd/config/example.go

<li>Added <code>Autoscaler</code> field with <code>nil</code> value in multiple configurations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/nhost/cli/pull/889/files#diff-49de1d039dc29237e62d701aea07feeeb61ca2f6b2fd3c8ca5ac36c68e1396ec">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config_example.go</strong><dd><code>Add `Autoscaler` field to configuration in run command</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
cmd/run/config_example.go

- Added `Autoscaler` field with `nil` value in configuration.



</details>
    

  </td>
  <td><a href="https://github.com/nhost/cli/pull/889/files#diff-53f28190938053c781895e1144af2be14737313324432c6d148f08c6f66cc6fb">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>compose.go</strong><dd><code>Update image version format in Docker Compose functions</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
dockercompose/compose.go

- Updated image version format to include Node.js version.



</details>
    

  </td>
  <td><a href="https://github.com/nhost/cli/pull/889/files#diff-67d473eea1a53a8257f907983067eaabe35308b83d3a28d7f7705e7dfa396c40">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>main_test.go</strong><dd><code>Add `Autoscaler` field to configurations in main test</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
dockercompose/main_test.go

<li>Added <code>Autoscaler</code> field with <code>nil</code> value in multiple configurations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/nhost/cli/pull/889/files#diff-cbd7bf3ae89752b4e39860c598bf584d6fecb846d098ad2fb9bafa5b205774fa">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>run_test.go</strong><dd><code>Add `Autoscaler` field to configuration in run test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
dockercompose/run_test.go

- Added `Autoscaler` field with `nil` value in configuration.



</details>
    

  </td>
  <td><a href="https://github.com/nhost/cli/pull/889/files#diff-5f681e9f78629ca300107bc7ea2ead326b817f0921529f645615f39e148db9f0">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>nhost.toml</strong><dd><code>Update Node.js version to 20 in example project</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
examples/myproject/nhost/nhost.toml

- Updated Node.js version from 18 to 20.



</details>
    

  </td>
  <td><a href="https://github.com/nhost/cli/pull/889/files#diff-ce9635d2304c2ca0ee06fd0e9d02f1b18238aa11c98c49aec9f58821031f1c44">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update Go version and dependencies in go.mod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
go.mod

<li>Updated Go version from 1.22.3 to 1.22.4.<br> <li> Updated <code>github.com/nhost/be</code> dependency version.<br>


</details>
    

  </td>
  <td><a href="https://github.com/nhost/cli/pull/889/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>go.sum</strong><dd><code>Update checksums for dependencies in go.sum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
go.sum

- Added new checksums for updated `github.com/nhost/be` dependency.



</details>
    

  </td>
  <td><a href="https://github.com/nhost/cli/pull/889/files#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

