### PR TITLE
feat: allow selecting local subdomain

### DIFF
--- a/clienv/clienv.go
+++ b/clienv/clienv.go
@@ -27,6 +27,7 @@ type CliEnv struct {
 	nhclient       *nhostclient.Client
 	nhpublicclient *nhostclient.Client
 	projectName    string
+	localSubdomain string
 }
 
 func New(
@@ -36,6 +37,7 @@ func New(
 	domain string,
 	branch string,
 	projectName string,
+	localSubdomain string,
 ) *CliEnv {
 	return &CliEnv{
 		stdout:         stdout,
@@ -46,6 +48,7 @@ func New(
 		nhclient:       nil,
 		nhpublicclient: nil,
 		projectName:    projectName,
+		localSubdomain: localSubdomain,
 	}
 }
 
@@ -69,11 +72,16 @@ func FromCLI(cCtx *cli.Context) *CliEnv {
 		projectName:    sanitizeName(cCtx.String(flagProjectName)),
 		nhclient:       nil,
 		nhpublicclient: nil,
+		localSubdomain: cCtx.String(flagLocalSubdomain),
 	}
 }
 
 func (ce *CliEnv) ProjectName() string {
 	return ce.projectName
+}
+
+func (ce *CliEnv) LocalSubdomain() string {
+	return ce.localSubdomain
 }
 
 func (ce *CliEnv) Domain() string {

--- a/clienv/flags.go
+++ b/clienv/flags.go
@@ -17,6 +17,7 @@ const (
 	flagDataFolder     = "data-folder"
 	flagNhostFolder    = "nhost-folder"
 	flagDotNhostFolder = "dot-nhost-folder"
+	flagLocalSubdomain = "local-subdomain"
 )
 
 func getGitBranchName() string {
@@ -97,6 +98,12 @@ func Flags() ([]cli.Flag, error) { //nolint:funlen
 			Usage:   "Project name",
 			Value:   filepath.Base(fullWorkingDir),
 			EnvVars: []string{"NHOST_PROJECT_NAME"},
+		},
+		&cli.StringFlag{ //nolint:exhaustruct
+			Name:    flagLocalSubdomain,
+			Usage:   "Local subdomain to reach the development environment",
+			Value:   "local",
+			EnvVars: []string{"NHOST_LOCAL_SUBDOMAIN"},
 		},
 	}, nil
 }

--- a/cmd/config/validate_test.go
+++ b/cmd/config/validate_test.go
@@ -215,6 +215,7 @@ func TestValidate(t *testing.T) {
 				"fakedomain",
 				"fakebranch",
 				"",
+				"local",
 			)
 
 			var secrets model.Secrets

--- a/cmd/dev/hasura.go
+++ b/cmd/dev/hasura.go
@@ -32,6 +32,7 @@ func commandHasura(cCtx *cli.Context) error {
 	docker := dockercompose.NewDocker()
 	return docker.HasuraWrapper( //nolint:wrapcheck
 		cCtx.Context,
+		ce.LocalSubdomain(),
 		ce.Path.NhostFolder(),
 		*cfg.Hasura.Version,
 		cCtx.Args().Slice()...,

--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -350,6 +350,7 @@ func up( //nolint:funlen,cyclop
 	ce.Infoln("Setting up Nhost development environment...")
 	composeFile, err := dockercompose.ComposeFileFromConfig(
 		cfg,
+		ce.LocalSubdomain(),
 		ce.ProjectName(),
 		httpPort,
 		useTLS,
@@ -393,7 +394,7 @@ func up( //nolint:funlen,cyclop
 		"metadata", "export",
 		"--skip-update-check",
 		"--log-level", "ERROR",
-		"--endpoint", dockercompose.URL("hasura", httpPort, useTLS),
+		"--endpoint", dockercompose.URL(ce.LocalSubdomain(), "hasura", httpPort, useTLS),
 		"--admin-secret", cfg.Hasura.AdminSecret,
 	); err != nil {
 		return fmt.Errorf("failed to create metadata: %w", err)
@@ -404,11 +405,12 @@ func up( //nolint:funlen,cyclop
 	}
 
 	ce.Infoln("Nhost development environment started.")
-	printInfo(httpPort, postgresPort, useTLS, runServicesCfg)
+	printInfo(ce.LocalSubdomain(), httpPort, postgresPort, useTLS, runServicesCfg)
 	return nil
 }
 
 func printInfo(
+	subdomain string,
 	httpPort, postgresPort uint,
 	useTLS bool,
 	runServices []*dockercompose.RunService,
@@ -419,20 +421,20 @@ func printInfo(
 		"- Postgres:\t\tpostgres://postgres:postgres@localhost:%d/local\n",
 		postgresPort,
 	)
-	fmt.Fprintf(w, "- Hasura:\t\t%s\n", dockercompose.URLNewFormat(
-		"local", "hasura", httpPort, useTLS))
-	fmt.Fprintf(w, "- GraphQL:\t\t%s\n", dockercompose.URLNewFormat(
-		"local", "graphql", httpPort, useTLS))
-	fmt.Fprintf(w, "- Auth:\t\t%s\n", dockercompose.URLNewFormat(
-		"local", "auth", httpPort, useTLS))
-	fmt.Fprintf(w, "- Storage:\t\t%s\n", dockercompose.URLNewFormat(
-		"local", "storage", httpPort, useTLS))
-	fmt.Fprintf(w, "- Functions:\t\t%s\n", dockercompose.URLNewFormat(
-		"local", "functions", httpPort, useTLS))
-	fmt.Fprintf(w, "- Dashboard:\t\t%s\n", dockercompose.URLNewFormat(
-		"local", "dashboard", httpPort, useTLS))
-	fmt.Fprintf(w, "- Mailhog:\t\t%s\n", dockercompose.URLNewFormat(
-		"local", "mailhog", httpPort, useTLS))
+	fmt.Fprintf(w, "- Hasura:\t\t%s\n", dockercompose.URL(
+		subdomain, "hasura", httpPort, useTLS))
+	fmt.Fprintf(w, "- GraphQL:\t\t%s\n", dockercompose.URL(
+		subdomain, "graphql", httpPort, useTLS))
+	fmt.Fprintf(w, "- Auth:\t\t%s\n", dockercompose.URL(
+		subdomain, "auth", httpPort, useTLS))
+	fmt.Fprintf(w, "- Storage:\t\t%s\n", dockercompose.URL(
+		subdomain, "storage", httpPort, useTLS))
+	fmt.Fprintf(w, "- Functions:\t\t%s\n", dockercompose.URL(
+		subdomain, "functions", httpPort, useTLS))
+	fmt.Fprintf(w, "- Dashboard:\t\t%s\n", dockercompose.URL(
+		subdomain, "dashboard", httpPort, useTLS))
+	fmt.Fprintf(w, "- Mailhog:\t\t%s\n", dockercompose.URL(
+		subdomain, "mailhog", httpPort, useTLS))
 
 	for _, svc := range runServices {
 		for _, port := range svc.Config.GetPorts() {
@@ -457,7 +459,7 @@ func printInfo(
 
 	fmt.Fprintf(w, "\n")
 	fmt.Fprintf(w, "SDK Configuration:\n")
-	fmt.Fprintf(w, " Subdomain:\tlocal\n")
+	fmt.Fprintf(w, " Subdomain:\t%s\n", subdomain)
 	fmt.Fprintf(w, " Region:\tlocal\n")
 	fmt.Fprintf(w, "")
 	fmt.Fprintf(w, "Run `nhost up` to reload the development environment\n")

--- a/cmd/dockercredentials/get.go
+++ b/cmd/dockercredentials/get.go
@@ -42,6 +42,7 @@ func getToken(ctx context.Context, domain string) (string, error) {
 		domain,
 		"unneeded",
 		"unneeded",
+		"unneeded",
 	)
 	session, err := ce.LoadSession(ctx)
 	if err != nil {

--- a/dockercompose/ai.go
+++ b/dockercompose/ai.go
@@ -7,6 +7,7 @@ import (
 
 func ai(
 	cfg *model.ConfigConfig,
+	subdomain string,
 ) *Service {
 	envars := appconfig.AIEnv(
 		cfg,
@@ -38,7 +39,7 @@ func ai(
 			"serve",
 		},
 		Environment: env,
-		ExtraHosts:  extraHosts(),
+		ExtraHosts:  extraHosts(subdomain),
 		Labels:      nil,
 		Ports:       nil,
 		Restart:     "always",

--- a/dockercompose/ai_test.go
+++ b/dockercompose/ai_test.go
@@ -31,12 +31,12 @@ func expectedAI() *Service {
 		},
 		ExtraHosts: []string{
 			"host.docker.internal:host-gateway",
-			"local.auth.nhost.run:host-gateway",
-			"local.db.nhost.run:host-gateway",
-			"local.functions.nhost.run:host-gateway",
-			"local.graphql.nhost.run:host-gateway",
-			"local.hasura.nhost.run:host-gateway",
-			"local.storage.nhost.run:host-gateway",
+			"dev.auth.local.nhost.run:host-gateway",
+			"dev.db.local.nhost.run:host-gateway",
+			"dev.functions.local.nhost.run:host-gateway",
+			"dev.graphql.local.nhost.run:host-gateway",
+			"dev.hasura.local.nhost.run:host-gateway",
+			"dev.storage.local.nhost.run:host-gateway",
 		},
 		HealthCheck: &HealthCheck{
 			Test:        []string{"CMD", "graphite", "healthcheck"},
@@ -70,7 +70,7 @@ func TestAI(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := ai(tc.cfg())
+			got := ai(tc.cfg(), "dev")
 			if diff := cmp.Diff(tc.expected(), got); diff != "" {
 				t.Error(diff)
 			}

--- a/dockercompose/auth.go
+++ b/dockercompose/auth.go
@@ -28,6 +28,7 @@ func authPatchPre022(svc Service, useTLS bool) *Service {
 
 func auth( //nolint:funlen
 	cfg *model.ConfigConfig,
+	subdomain string,
 	httpPort uint,
 	useTLS bool,
 	nhostFolder string,
@@ -36,7 +37,7 @@ func auth( //nolint:funlen
 	envars, err := appconfig.HasuraAuthEnv(
 		cfg,
 		"http://graphql:8080/v1/graphql",
-		URL("auth", httpPort, useTLS)+"/v1",
+		URL(subdomain, "auth", httpPort, useTLS)+"/v1",
 		"postgres://nhost_hasura@postgres:5432/local",
 		"postgres://nhost_auth_admin@postgres:5432/local",
 		&model.ConfigSmtp{
@@ -70,7 +71,7 @@ func auth( //nolint:funlen
 		EntryPoint:  nil,
 		Command:     nil,
 		Environment: env,
-		ExtraHosts:  extraHosts(),
+		ExtraHosts:  extraHosts(subdomain),
 		HealthCheck: &HealthCheck{
 			Test:        []string{"CMD", "wget", "--spider", "-S", "http://localhost:4000/healthz"},
 			Timeout:     "60s",

--- a/dockercompose/auth_test.go
+++ b/dockercompose/auth_test.go
@@ -104,7 +104,7 @@ func expectedAuth() *Service {
 			"AUTH_PROVIDER_WORKOS_ENABLED":              "true",
 			"AUTH_REFRESH_TOKEN_EXPIRES_IN":             "99",
 			"AUTH_REQUIRE_ELEVATED_CLAIM":               "required",
-			"AUTH_SERVER_URL":                           "http://local.auth.nhost.run:1336/v1",
+			"AUTH_SERVER_URL":                           "http://dev.auth.local.nhost.run:1336/v1",
 			"AUTH_SMS_PASSWORDLESS_ENABLED":             "true",
 			"AUTH_SMS_PROVIDER":                         "twilio",
 			"AUTH_SMS_TWILIO_ACCOUNT_SID":               "smsAccountSid",
@@ -133,10 +133,13 @@ func expectedAuth() *Service {
 			"HASURA_GRAPHQL_JWT_SECRET":                 `{"claims_map":{"x-hasura-allowed-roles":{"path":"$.roles"},"x-hasura-default-role":"viewer","x-hasura-org-id":{"default":"public","path":"$.org"},"x-hasura-user-id":{"path":"$.sub"}},"key":"jwtSecretKey","type":"HS256"}`,
 		},
 		ExtraHosts: []string{
-			"host.docker.internal:host-gateway", "local.auth.nhost.run:host-gateway",
-			"local.db.nhost.run:host-gateway", "local.functions.nhost.run:host-gateway",
-			"local.graphql.nhost.run:host-gateway", "local.hasura.nhost.run:host-gateway",
-			"local.storage.nhost.run:host-gateway",
+			"host.docker.internal:host-gateway",
+			"dev.auth.local.nhost.run:host-gateway",
+			"dev.db.local.nhost.run:host-gateway",
+			"dev.functions.local.nhost.run:host-gateway",
+			"dev.graphql.local.nhost.run:host-gateway",
+			"dev.hasura.local.nhost.run:host-gateway",
+			"dev.storage.local.nhost.run:host-gateway",
 		},
 		HealthCheck: &HealthCheck{
 			Test:        []string{"CMD", "wget", "--spider", "-S", "http://localhost:4000/healthz"},
@@ -206,7 +209,7 @@ func TestAuth(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := auth(tc.cfg(), 1336, tc.useTlS, "/tmp/nhost", 0)
+			got, err := auth(tc.cfg(), "dev", 1336, tc.useTlS, "/tmp/nhost", 0)
 			if err != nil {
 				t.Errorf("got error: %v", err)
 			}

--- a/dockercompose/docker.go
+++ b/dockercompose/docker.go
@@ -21,6 +21,7 @@ func NewDocker() *Docker {
 
 func (d *Docker) HasuraWrapper(
 	ctx context.Context,
+	subdomain,
 	nhostfolder,
 	hasuraVersion string,
 	exrtaArgs ...string,
@@ -38,7 +39,7 @@ func (d *Docker) HasuraWrapper(
 		"--entrypoint", "hasura-cli",
 	}
 
-	for _, host := range extraHosts() {
+	for _, host := range extraHosts(subdomain) {
 		args = append(args, "--add-host", host)
 	}
 

--- a/dockercompose/graphql_test.go
+++ b/dockercompose/graphql_test.go
@@ -57,10 +57,13 @@ func expectedGraphql() *Service {
 			"NHOST_WEBHOOK_SECRET":                                     "webhookSecret",
 		},
 		ExtraHosts: []string{
-			"host.docker.internal:host-gateway", "local.auth.nhost.run:host-gateway",
-			"local.db.nhost.run:host-gateway", "local.functions.nhost.run:host-gateway",
-			"local.graphql.nhost.run:host-gateway", "local.hasura.nhost.run:host-gateway",
-			"local.storage.nhost.run:host-gateway",
+			"host.docker.internal:host-gateway",
+			"dev.auth.local.nhost.run:host-gateway",
+			"dev.db.local.nhost.run:host-gateway",
+			"dev.functions.local.nhost.run:host-gateway",
+			"dev.graphql.local.nhost.run:host-gateway",
+			"dev.hasura.local.nhost.run:host-gateway",
+			"dev.storage.local.nhost.run:host-gateway",
 		},
 		HealthCheck: &HealthCheck{
 			Test: []string{
@@ -115,7 +118,7 @@ func TestGraphql(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := graphql(tc.cfg(), tc.useTlS, 1337, 0)
+			got, err := graphql(tc.cfg(), "dev", tc.useTlS, 1337, 0)
 			if err != nil {
 				t.Errorf("got error: %v", err)
 			}
@@ -141,8 +144,8 @@ func expectedConsole() *Service {
                     --address 0.0.0.0 \
                     --console-port 9695 \
                     --api-port 1337 \
-                    --api-host http://local.hasura.nhost.run \
-                    --console-hge-endpoint http://local.hasura.nhost.run:1337`,
+                    --api-host http://dev.hasura.local.nhost.run \
+                    --console-hge-endpoint http://dev.hasura.local.nhost.run:1337`,
 		},
 		EntryPoint: nil,
 		Environment: map[string]string{
@@ -186,10 +189,13 @@ func expectedConsole() *Service {
 			"NHOST_WEBHOOK_SECRET":                                     "webhookSecret",
 		},
 		ExtraHosts: []string{
-			"host.docker.internal:host-gateway", "local.auth.nhost.run:host-gateway",
-			"local.db.nhost.run:host-gateway", "local.functions.nhost.run:host-gateway",
-			"local.graphql.nhost.run:host-gateway", "local.hasura.nhost.run:0.0.0.0",
-			"local.storage.nhost.run:host-gateway",
+			"host.docker.internal:host-gateway",
+			"dev.auth.local.nhost.run:host-gateway",
+			"dev.db.local.nhost.run:host-gateway",
+			"dev.functions.local.nhost.run:host-gateway",
+			"dev.graphql.local.nhost.run:host-gateway",
+			"dev.hasura.local.nhost.run:host-gateway",
+			"dev.storage.local.nhost.run:host-gateway",
 		},
 		HealthCheck: &HealthCheck{
 			Test: []string{
@@ -251,7 +257,7 @@ func TestConsole(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := console(tc.cfg(), 1337, tc.useTlS, "/path/to/nhost", 0)
+			got, err := console(tc.cfg(), "dev", 1337, tc.useTlS, "/path/to/nhost", 0)
 			if err != nil {
 				t.Fatalf("got error: %v", err)
 			}

--- a/dockercompose/graphql_test.go
+++ b/dockercompose/graphql_test.go
@@ -23,7 +23,7 @@ func expectedGraphql() *Service {
 			"HASURA_GRAPHQL_ADMIN_INTERNAL_ERRORS":                     "true",
 			"HASURA_GRAPHQL_ADMIN_SECRET":                              "adminSecret",
 			"HASURA_GRAPHQL_CONSOLE_ASSETS_DIR":                        "/srv/console-assets",
-			"HASURA_GRAPHQL_CORS_DOMAIN":                               "http://*.localhost,http://*.hasura.local.nhost.run:1337",
+			"HASURA_GRAPHQL_CORS_DOMAIN":                               "http://*.localhost,http://*.hasura.local.nhost.run:1337,http://*.dashboard.local.nhost.run:1337",
 			"HASURA_GRAPHQL_DATABASE_URL":                              "postgres://nhost_hasura@postgres:5432/local",
 			"HASURA_GRAPHQL_DEV_MODE":                                  "false",
 			"HASURA_GRAPHQL_DISABLE_CORS":                              "false",

--- a/dockercompose/postgres.go
+++ b/dockercompose/postgres.go
@@ -11,6 +11,7 @@ import (
 
 func postgres( //nolint:funlen
 	cfg *model.ConfigConfig,
+	subdomain string,
 	port uint,
 	dataFolder string,
 	volumeName string,
@@ -57,7 +58,7 @@ func postgres( //nolint:funlen
 			"-c", "hba_file=/etc/pg_hba_local.conf",
 		},
 		Environment: env,
-		ExtraHosts:  extraHosts(),
+		ExtraHosts:  extraHosts(subdomain),
 		HealthCheck: &HealthCheck{
 			Test: []string{
 				"CMD-SHELL", "pg_isready -U postgres", "-d", "postgres", "-q",

--- a/dockercompose/postgres_test.go
+++ b/dockercompose/postgres_test.go
@@ -26,10 +26,13 @@ func expectedPostgres(tmpdir string) *Service {
 			"POSTGRES_USER":         "postgres",
 		},
 		ExtraHosts: []string{
-			"host.docker.internal:host-gateway", "local.auth.nhost.run:host-gateway",
-			"local.db.nhost.run:host-gateway", "local.functions.nhost.run:host-gateway",
-			"local.graphql.nhost.run:host-gateway", "local.hasura.nhost.run:host-gateway",
-			"local.storage.nhost.run:host-gateway",
+			"host.docker.internal:host-gateway",
+			"dev.auth.local.nhost.run:host-gateway",
+			"dev.db.local.nhost.run:host-gateway",
+			"dev.functions.local.nhost.run:host-gateway",
+			"dev.graphql.local.nhost.run:host-gateway",
+			"dev.hasura.local.nhost.run:host-gateway",
+			"dev.storage.local.nhost.run:host-gateway",
 		},
 		HealthCheck: &HealthCheck{
 			Test:        []string{"CMD-SHELL", "pg_isready -U postgres", "-d", "postgres", "-q"},
@@ -78,7 +81,7 @@ func TestPostgres(t *testing.T) {
 			t.Parallel()
 
 			tmpdir := filepath.Join(os.TempDir(), "data")
-			got, err := postgres(tc.cfg(), 5432, tmpdir, "pgdate_test")
+			got, err := postgres(tc.cfg(), "dev", 5432, tmpdir, "pgdate_test")
 			if err != nil {
 				t.Errorf("got error: %v", err)
 			}

--- a/dockercompose/run.go
+++ b/dockercompose/run.go
@@ -17,6 +17,7 @@ func runVolumeName(
 
 func run(
 	cfg *model.ConfigRunServiceConfig,
+	subdomain string,
 	branchName string,
 ) *Service {
 	env := map[string]string{}
@@ -56,7 +57,7 @@ func run(
 		EntryPoint:  cfg.GetCommand(),
 		Command:     []string{},
 		Environment: env,
-		ExtraHosts:  extraHosts(),
+		ExtraHosts:  extraHosts(subdomain),
 		HealthCheck: nil,
 		Labels:      map[string]string{},
 		Ports:       ports,

--- a/dockercompose/run_test.go
+++ b/dockercompose/run_test.go
@@ -91,12 +91,12 @@ func TestRun(t *testing.T) {
 					Environment: map[string]string{"ENV": "value", "ENV2": "value2"},
 					ExtraHosts: []string{
 						"host.docker.internal:host-gateway",
-						"local.auth.nhost.run:host-gateway",
-						"local.db.nhost.run:host-gateway",
-						"local.functions.nhost.run:host-gateway",
-						"local.graphql.nhost.run:host-gateway",
-						"local.hasura.nhost.run:host-gateway",
-						"local.storage.nhost.run:host-gateway",
+						"dev.auth.local.nhost.run:host-gateway",
+						"dev.db.local.nhost.run:host-gateway",
+						"dev.functions.local.nhost.run:host-gateway",
+						"dev.graphql.local.nhost.run:host-gateway",
+						"dev.hasura.local.nhost.run:host-gateway",
+						"dev.storage.local.nhost.run:host-gateway",
 					},
 					Labels: map[string]string{},
 					Ports: []Port{
@@ -122,7 +122,7 @@ func TestRun(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := run(tc.cfg(), "branch")
+			got := run(tc.cfg(), "dev", "branch")
 			if diff := cmp.Diff(tc.expected(), got); diff != "" {
 				t.Error(diff)
 			}

--- a/dockercompose/storage.go
+++ b/dockercompose/storage.go
@@ -16,6 +16,7 @@ func deptr[T any](t *T) T { //nolint:ireturn
 
 func storage( //nolint:funlen
 	cfg *model.ConfigConfig,
+	subdomain string,
 	useTLS bool,
 	httpPort uint,
 	exposePort uint,
@@ -24,7 +25,7 @@ func storage( //nolint:funlen
 		cfg,
 		"http://graphql:8080/v1",
 		"postgres://nhost_storage_admin@postgres:5432/local?sslmode=disable",
-		URL("storage", httpPort, useTLS),
+		URL(subdomain, "storage", httpPort, useTLS),
 		"http://minio:9000",
 		"",
 		"nhost",
@@ -60,7 +61,7 @@ func storage( //nolint:funlen
 			"serve",
 		},
 		Environment: env,
-		ExtraHosts:  extraHosts(),
+		ExtraHosts:  extraHosts(subdomain),
 		Labels: Ingresses{
 			{
 				Name:    "storage",

--- a/dockercompose/storage_test.go
+++ b/dockercompose/storage_test.go
@@ -24,7 +24,7 @@ func expectedStorage() *Service {
 			"HASURA_METADATA":             "1",
 			"POSTGRES_MIGRATIONS":         "1",
 			"POSTGRES_MIGRATIONS_SOURCE":  "postgres://nhost_storage_admin@postgres:5432/local?sslmode=disable",
-			"PUBLIC_URL":                  "http://local.storage.nhost.run:444",
+			"PUBLIC_URL":                  "http://dev.storage.local.nhost.run:444",
 			"S3_ACCESS_KEY":               "minioaccesskey123123",
 			"S3_BUCKET":                   "nhost",
 			"S3_ENDPOINT":                 "http://minio:9000",
@@ -34,10 +34,13 @@ func expectedStorage() *Service {
 			"CLAMAV_SERVER":               "tcp://run-clamav:3310",
 		},
 		ExtraHosts: []string{
-			"host.docker.internal:host-gateway", "local.auth.nhost.run:host-gateway",
-			"local.db.nhost.run:host-gateway", "local.functions.nhost.run:host-gateway",
-			"local.graphql.nhost.run:host-gateway", "local.hasura.nhost.run:host-gateway",
-			"local.storage.nhost.run:host-gateway",
+			"host.docker.internal:host-gateway",
+			"dev.auth.local.nhost.run:host-gateway",
+			"dev.db.local.nhost.run:host-gateway",
+			"dev.functions.local.nhost.run:host-gateway",
+			"dev.graphql.local.nhost.run:host-gateway",
+			"dev.hasura.local.nhost.run:host-gateway",
+			"dev.storage.local.nhost.run:host-gateway",
 		},
 		HealthCheck: nil,
 		Labels: map[string]string{
@@ -76,7 +79,7 @@ func TestStorage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := storage(tc.cfg(), tc.useTlS, 444, 0)
+			got, err := storage(tc.cfg(), "dev", tc.useTlS, 444, 0)
 			if err != nil {
 				t.Errorf("got error: %v", err)
 			}

--- a/dockercompose/url.go
+++ b/dockercompose/url.go
@@ -2,21 +2,7 @@ package dockercompose
 
 import "fmt"
 
-func URL(service string, port uint, useTLS bool) string {
-	if useTLS && port == 443 {
-		return fmt.Sprintf("https://local.%s.nhost.run", service)
-	} else if !useTLS && port == 80 {
-		return fmt.Sprintf("http://local.%s.nhost.run", service)
-	}
-
-	protocol := "http"
-	if useTLS {
-		protocol = "https"
-	}
-	return fmt.Sprintf("%s://local.%s.nhost.run:%d", protocol, service, port)
-}
-
-func URLNewFormat(host, service string, port uint, useTLS bool) string {
+func URL(host, service string, port uint, useTLS bool) string {
 	if useTLS && port == 443 {
 		return fmt.Sprintf("https://%s.%s.local.nhost.run", host, service)
 	} else if !useTLS && port == 80 {

--- a/nhostclient/graphql/models_gen.go
+++ b/nhostclient/graphql/models_gen.go
@@ -72,6 +72,7 @@ type ConfigAIUpdateInput struct {
 type ConfigAuth struct {
 	ElevatedPrivileges *ConfigAuthElevatedPrivileges `json:"elevatedPrivileges,omitempty"`
 	Method             *ConfigAuthMethod             `json:"method,omitempty"`
+	RateLimit          *ConfigAuthRateLimit          `json:"rateLimit,omitempty"`
 	Redirections       *ConfigAuthRedirections       `json:"redirections,omitempty"`
 	Resources          *ConfigResources              `json:"resources,omitempty"`
 	Session            *ConfigAuthSession            `json:"session,omitempty"`
@@ -271,6 +272,22 @@ type ConfigAuthMethodWebauthnUpdateInput struct {
 	RelyingParty *ConfigAuthMethodWebauthnRelyingPartyUpdateInput `json:"relyingParty,omitempty"`
 }
 
+type ConfigAuthRateLimit struct {
+	BruteForce *ConfigRateLimit `json:"bruteForce,omitempty"`
+	Emails     *ConfigRateLimit `json:"emails,omitempty"`
+	Global     *ConfigRateLimit `json:"global,omitempty"`
+	Signups    *ConfigRateLimit `json:"signups,omitempty"`
+	Sms        *ConfigRateLimit `json:"sms,omitempty"`
+}
+
+type ConfigAuthRateLimitUpdateInput struct {
+	BruteForce *ConfigRateLimitUpdateInput `json:"bruteForce,omitempty"`
+	Emails     *ConfigRateLimitUpdateInput `json:"emails,omitempty"`
+	Global     *ConfigRateLimitUpdateInput `json:"global,omitempty"`
+	Signups    *ConfigRateLimitUpdateInput `json:"signups,omitempty"`
+	Sms        *ConfigRateLimitUpdateInput `json:"sms,omitempty"`
+}
+
 type ConfigAuthRedirections struct {
 	AllowedUrls []string `json:"allowedUrls,omitempty"`
 	ClientURL   *string  `json:"clientUrl,omitempty"`
@@ -332,6 +349,7 @@ type ConfigAuthTotpUpdateInput struct {
 type ConfigAuthUpdateInput struct {
 	ElevatedPrivileges *ConfigAuthElevatedPrivilegesUpdateInput `json:"elevatedPrivileges,omitempty"`
 	Method             *ConfigAuthMethodUpdateInput             `json:"method,omitempty"`
+	RateLimit          *ConfigAuthRateLimitUpdateInput          `json:"rateLimit,omitempty"`
 	Redirections       *ConfigAuthRedirectionsUpdateInput       `json:"redirections,omitempty"`
 	Resources          *ConfigResourcesUpdateInput              `json:"resources,omitempty"`
 	Session            *ConfigAuthSessionUpdateInput            `json:"session,omitempty"`
@@ -503,6 +521,7 @@ type ConfigEnvironmentVariableUpdateInput struct {
 
 type ConfigFunctions struct {
 	Node      *ConfigFunctionsNode      `json:"node,omitempty"`
+	RateLimit *ConfigRateLimit          `json:"rateLimit,omitempty"`
 	Resources *ConfigFunctionsResources `json:"resources,omitempty"`
 }
 
@@ -524,6 +543,7 @@ type ConfigFunctionsResourcesUpdateInput struct {
 
 type ConfigFunctionsUpdateInput struct {
 	Node      *ConfigFunctionsNodeUpdateInput      `json:"node,omitempty"`
+	RateLimit *ConfigRateLimitUpdateInput          `json:"rateLimit,omitempty"`
 	Resources *ConfigFunctionsResourcesUpdateInput `json:"resources,omitempty"`
 }
 
@@ -577,6 +597,7 @@ type ConfigHasura struct {
 	Events        *ConfigHasuraEvents   `json:"events,omitempty"`
 	JwtSecrets    []*ConfigJWTSecret    `json:"jwtSecrets,omitempty"`
 	Logs          *ConfigHasuraLogs     `json:"logs,omitempty"`
+	RateLimit     *ConfigRateLimit      `json:"rateLimit,omitempty"`
 	Resources     *ConfigResources      `json:"resources,omitempty"`
 	Settings      *ConfigHasuraSettings `json:"settings,omitempty"`
 	Version       *string               `json:"version,omitempty"`
@@ -639,6 +660,7 @@ type ConfigHasuraUpdateInput struct {
 	Events        *ConfigHasuraEventsUpdateInput   `json:"events,omitempty"`
 	JwtSecrets    []*ConfigJWTSecretUpdateInput    `json:"jwtSecrets,omitempty"`
 	Logs          *ConfigHasuraLogsUpdateInput     `json:"logs,omitempty"`
+	RateLimit     *ConfigRateLimitUpdateInput      `json:"rateLimit,omitempty"`
 	Resources     *ConfigResourcesUpdateInput      `json:"resources,omitempty"`
 	Settings      *ConfigHasuraSettingsUpdateInput `json:"settings,omitempty"`
 	Version       *string                          `json:"version,omitempty"`
@@ -815,6 +837,21 @@ type ConfigProviderUpdateInput struct {
 	SMTP *ConfigSMTPUpdateInput `json:"smtp,omitempty"`
 }
 
+type ConfigRateLimit struct {
+	Interval string `json:"interval"`
+	Limit    uint32 `json:"limit"`
+}
+
+type ConfigRateLimitInsertInput struct {
+	Interval string `json:"interval"`
+	Limit    uint32 `json:"limit"`
+}
+
+type ConfigRateLimitUpdateInput struct {
+	Interval *string `json:"interval,omitempty"`
+	Limit    *uint32 `json:"limit,omitempty"`
+}
+
 type ConfigResources struct {
 	Autoscaler *ConfigAutoscaler       `json:"autoscaler,omitempty"`
 	Compute    *ConfigResourcesCompute `json:"compute,omitempty"`
@@ -890,6 +927,7 @@ type ConfigRunServicePort struct {
 	Ingresses []*ConfigIngress `json:"ingresses,omitempty"`
 	Port      uint32           `json:"port"`
 	Publish   *bool            `json:"publish,omitempty"`
+	RateLimit *ConfigRateLimit `json:"rateLimit,omitempty"`
 	Type      string           `json:"type"`
 }
 
@@ -897,6 +935,7 @@ type ConfigRunServicePortInsertInput struct {
 	Ingresses []*ConfigIngressInsertInput `json:"ingresses,omitempty"`
 	Port      uint32                      `json:"port"`
 	Publish   *bool                       `json:"publish,omitempty"`
+	RateLimit *ConfigRateLimitInsertInput `json:"rateLimit,omitempty"`
 	Type      string                      `json:"type"`
 }
 
@@ -904,6 +943,7 @@ type ConfigRunServicePortUpdateInput struct {
 	Ingresses []*ConfigIngressUpdateInput `json:"ingresses,omitempty"`
 	Port      *uint32                     `json:"port,omitempty"`
 	Publish   *bool                       `json:"publish,omitempty"`
+	RateLimit *ConfigRateLimitUpdateInput `json:"rateLimit,omitempty"`
 	Type      *string                     `json:"type,omitempty"`
 }
 
@@ -1008,6 +1048,7 @@ type ConfigStandardOauthProviderWithScopeUpdateInput struct {
 
 type ConfigStorage struct {
 	Antivirus *ConfigStorageAntivirus `json:"antivirus,omitempty"`
+	RateLimit *ConfigRateLimit        `json:"rateLimit,omitempty"`
 	Resources *ConfigResources        `json:"resources,omitempty"`
 	Version   *string                 `json:"version,omitempty"`
 }
@@ -1022,6 +1063,7 @@ type ConfigStorageAntivirusUpdateInput struct {
 
 type ConfigStorageUpdateInput struct {
 	Antivirus *ConfigStorageAntivirusUpdateInput `json:"antivirus,omitempty"`
+	RateLimit *ConfigRateLimitUpdateInput        `json:"rateLimit,omitempty"`
 	Resources *ConfigResourcesUpdateInput        `json:"resources,omitempty"`
 	Version   *string                            `json:"version,omitempty"`
 }
@@ -1084,17 +1126,6 @@ type IntComparisonExp struct {
 	Lte    *int64  `json:"_lte,omitempty"`
 	Neq    *int64  `json:"_neq,omitempty"`
 	Nin    []int64 `json:"_nin,omitempty"`
-}
-
-type InvoiceItem struct {
-	Amount      string `json:"Amount"`
-	Description string `json:"Description"`
-}
-
-type InvoiceSummary struct {
-	AmountDue string         `json:"AmountDue"`
-	PeriodEnd string         `json:"PeriodEnd"`
-	Items     []*InvoiceItem `json:"items"`
 }
 
 type LastError struct {


### PR DESCRIPTION
Adds `local-subdomain` flag to set new-style's subdomain (old style still works):

```
❯ nhost --local-subdomain 127-0-0-1 up
Checking versions...
✅ Auth is already on a recommended version: 0.30.0
🟡 Storage is not on a recommended version. Recommended: 0.6.1
   More info: https://github.com/nhost/hasura-storage/releases
🟡 PostgreSQL is not on a recommended version. Recommended: 14.11-20240515-1, 14.11-20240718-1, 15.6-20240718-1, 16.2-20240718-1
   More info: https://hub.docker.com/r/nhost/postgres
🟡 Hasura is not on a recommended version. Recommended: v2.38.0-ce
🟡 A new version of Nhost CLI is available: v1.21.0
   You can upgrade the CLI by running `nhost sw upgrade`
   More info: https://github.com/nhost/cli/releases
Setting up Nhost development environment...
Starting Nhost development environment...
[+] Running 11/11
 ✔ Container myproject-traefik-1       Healthy                                                           17.7s
 ✔ Container myproject-dashboard-1     Healthy                                                           17.7s
 ✔ Container myproject-functions-1     Healthy                                                           17.7s
 ✔ Container myproject-mailhog-1       Healthy                                                           17.7s
 ✔ Container myproject-minio-1         Healthy                                                           17.7s
 ✔ Container myproject-postgres-1      Healthy                                                           17.7s
 ✔ Container myproject-graphql-1       Healthy                                                           17.7s
 ✔ Container myproject-configserver-1  Healthy                                                           17.7s
 ✔ Container myproject-console-1       Healthy                                                           12.5s
 ✔ Container myproject-auth-1          Healthy                                                           12.5s
 ✔ Container myproject-storage-1       Healthy                                                            7.5s
Applying migrations...
INFO nothing to apply on database: default
Applying metadata...
Restarting services to reapply metadata if needed...
[+] Restarting 3/3
 ✔ Container myproject-functions-1  Started                                                              10.3s
 ✔ Container myproject-auth-1       Started                                                               0.6s
 ✔ Container myproject-storage-1    Started                                                               0.6s
Downloading metadata...
Unable to find image 'hasura/graphql-engine:metadata.cli-migrations-v3' locally
docker: Error response from daemon: manifest for hasura/graphql-engine:metadata.cli-migrations-v3 not found: manifest unknown: manifest unknown.
See 'docker run --help'.
Reapplying metadata...
INFO Metadata reloaded
WARN Metadata is inconsistent, use 'hasura metadata ic list' command to see the inconsistent objects
Nhost development environment started.
URLs:
- Postgres:         postgres://postgres:postgres@localhost:5432/local
- Hasura:           https://127-0-0-1.hasura.local.nhost.run
- GraphQL:          https://127-0-0-1.graphql.local.nhost.run
- Auth:             https://127-0-0-1.auth.local.nhost.run
- Storage:          https://127-0-0-1.storage.local.nhost.run
- Functions:        https://127-0-0-1.functions.local.nhost.run
- Dashboard:        https://127-0-0-1.dashboard.local.nhost.run
- Mailhog:          https://127-0-0-1.mailhog.local.nhost.run

SDK Configuration:
 Subdomain:    127-0-0-1
 Region:       local
Run `nhost up` to reload the development environment
Run `nhost down` to stop the development environment
Run `nhost logs` to watch the logs
```

It also sets the correct public urls for the various services accordingly (i.e. presigned urls for storage or callback urls for auth):

<img width="1088" alt="Screenshot 2024-08-15 at 14 17 40" src="https://github.com/user-attachments/assets/4e173f23-ec8d-43eb-867a-466649eb19f8">
