### PR TITLE
chore: bump nhost/dashboard to 1.27.0

### DIFF
--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -109,7 +109,7 @@ func CommandUp() *cli.Command { //nolint:funlen
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:1.25.0",
+				Value:   "nhost/dashboard:1.27.0",
 				EnvVars: []string{"NHOST_DASHBOARD_VERSION"},
 			},
 			&cli.StringFlag{ //nolint:exhaustruct

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-getter v1.7.5
-	github.com/nhost/be v0.0.0-20240827074322-bfcccb6fe6f4
+	github.com/nhost/be v0.0.0-20240827125525-b9345d4154be
 	github.com/pelletier/go-toml/v2 v2.2.2
 	github.com/rs/cors/wrapper/gin v0.0.0-20240515105523-1562b1715b35
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -517,6 +517,8 @@ github.com/nhost/be v0.0.0-20240820101832-63c0798e013b h1:ZCrX/vGfhnhx5HvjUJUbmK
 github.com/nhost/be v0.0.0-20240820101832-63c0798e013b/go.mod h1:iNulO8zDQ+jslaNRAm5NKY0W7sJeQ4INvQdS0AEN06w=
 github.com/nhost/be v0.0.0-20240827074322-bfcccb6fe6f4 h1:z8r2N7iNM0ijmfQ0BTaPLHpJgaFyztUSpbAfP1gSsnc=
 github.com/nhost/be v0.0.0-20240827074322-bfcccb6fe6f4/go.mod h1:iNulO8zDQ+jslaNRAm5NKY0W7sJeQ4INvQdS0AEN06w=
+github.com/nhost/be v0.0.0-20240827125525-b9345d4154be h1:FauI2dBeadFS9K6lX+uwhMMNAkufaOdp9WDg8f3CrSk=
+github.com/nhost/be v0.0.0-20240827125525-b9345d4154be/go.mod h1:iNulO8zDQ+jslaNRAm5NKY0W7sJeQ4INvQdS0AEN06w=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
 github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=

--- a/nhostclient/graphql/models_gen.go
+++ b/nhostclient/graphql/models_gen.go
@@ -72,6 +72,7 @@ type ConfigAIUpdateInput struct {
 type ConfigAuth struct {
 	ElevatedPrivileges *ConfigAuthElevatedPrivileges `json:"elevatedPrivileges,omitempty"`
 	Method             *ConfigAuthMethod             `json:"method,omitempty"`
+	Misc               *ConfigAuthMisc               `json:"misc,omitempty"`
 	RateLimit          *ConfigAuthRateLimit          `json:"rateLimit,omitempty"`
 	Redirections       *ConfigAuthRedirections       `json:"redirections,omitempty"`
 	Resources          *ConfigResources              `json:"resources,omitempty"`
@@ -272,6 +273,14 @@ type ConfigAuthMethodWebauthnUpdateInput struct {
 	RelyingParty *ConfigAuthMethodWebauthnRelyingPartyUpdateInput `json:"relyingParty,omitempty"`
 }
 
+type ConfigAuthMisc struct {
+	ConcealErrors *bool `json:"concealErrors,omitempty"`
+}
+
+type ConfigAuthMiscUpdateInput struct {
+	ConcealErrors *bool `json:"concealErrors,omitempty"`
+}
+
 type ConfigAuthRateLimit struct {
 	BruteForce *ConfigRateLimit `json:"bruteForce,omitempty"`
 	Emails     *ConfigRateLimit `json:"emails,omitempty"`
@@ -349,6 +358,7 @@ type ConfigAuthTotpUpdateInput struct {
 type ConfigAuthUpdateInput struct {
 	ElevatedPrivileges *ConfigAuthElevatedPrivilegesUpdateInput `json:"elevatedPrivileges,omitempty"`
 	Method             *ConfigAuthMethodUpdateInput             `json:"method,omitempty"`
+	Misc               *ConfigAuthMiscUpdateInput               `json:"misc,omitempty"`
 	RateLimit          *ConfigAuthRateLimitUpdateInput          `json:"rateLimit,omitempty"`
 	Redirections       *ConfigAuthRedirectionsUpdateInput       `json:"redirections,omitempty"`
 	Resources          *ConfigResourcesUpdateInput              `json:"resources,omitempty"`

--- a/vendor/github.com/nhost/be/services/mimir/schema/schema.cue
+++ b/vendor/github.com/nhost/be/services/mimir/schema/schema.cue
@@ -68,6 +68,10 @@ import (
 		(postgres.resources.compute == _|_) ) & true @cuegraph(skip)
 
 	_validateNetworkingMustBeNullOrNotSet: !storage.resources.networking | storage.resources.networking == null @cuegraph(skip)
+
+	_isProviderSMTPSet:                                     provider.smtp != _|_                                                        @cuegraph(skip)
+	_isAuthRateLimitEmailsDefault:                          auth.rateLimit.emails.limit == 10 && auth.rateLimit.emails.interval == "1h" @cuegraph(skip)
+	_validateAuthRateLimitEmailsIsDefaultOrSMTPSettingsSet: (_isProviderSMTPSet | _isAuthRateLimitEmailsDefault) & true                 @cuegraph(skip)
 }
 
 // Global configuration that applies to all services
@@ -101,7 +105,7 @@ import (
 }
 
 #Autoscaler: {
-    maxReplicas: uint8 & >=2 & <=100
+	maxReplicas: uint8 & >=2 & <=100
 }
 
 // Resource configuration for a service
@@ -120,14 +124,14 @@ import (
 	}
 
 	// Number of replicas for a service
-	replicas: uint8 & >=1 & <=10 | *1
-    autoscaler?: #Autoscaler
+	replicas:    uint8 & >=1 & <=10 | *1
+	autoscaler?: #Autoscaler
 
-    _validateReplicasMustBeSmallerThanMaxReplicas: (replicas <= autoscaler.maxReplicas) & true @cuegraph(skip)
+	_validateReplicasMustBeSmallerThanMaxReplicas: (replicas <= autoscaler.maxReplicas) & true @cuegraph(skip)
 
 	_validateMultipleReplicasNeedsCompute: (
-							replicas == 1 && autoscaler == _|_ |
-        compute != _|_) & true @cuegraph(skip)
+						replicas == 1 && autoscaler == _|_ |
+							compute != _|_) & true @cuegraph(skip)
 	_validateMultipleReplicasRatioMustBe1For2: (
 							replicas == 1 && autoscaler == _|_ |
 		(compute.cpu*2.048 == compute.memory)) & true @cuegraph(skip)
@@ -250,11 +254,11 @@ import (
 			capacity: uint32 & >=10 & <=1000 | *10 // GiB
 		}
 
-        enablePublicAccess?: bool | *false
+		enablePublicAccess?: bool | *false
 	} & {
 		replicas:    1
 		networking?: null
-        autoscaler?: null
+		autoscaler?: null
 	}
 
 	settings?: {
@@ -444,11 +448,11 @@ import (
 
 		webauthn: {
 			enabled: bool | *false
-            relyingParty?: {
-                id:    string | *""
-                name?: string
-                origins?: [...#Url] | *[redirections.clientUrl]
-            }
+			relyingParty?: {
+				id:    string | *""
+				name?: string
+				origins?: [...#Url] | *[redirections.clientUrl]
+			}
 			attestation: {
 				timeout: uint32 | *60000
 			}
@@ -465,9 +469,9 @@ import (
 		}
 	}
 
-    misc: {
-        concealErrors: bool | *false
-    }
+	misc: {
+		concealErrors: bool | *false
+	}
 
 	rateLimit: #AuthRateLimit
 }
@@ -572,9 +576,7 @@ import (
 		path:     string
 		default?: string
 	}
-} & {
-
-}
+} & {}
 
 #SystemConfig: {
 	auth: {
@@ -585,15 +587,15 @@ import (
 		}
 	}
 
-    graphql: {
-        // manually enable graphi on a per-service basis
-        // by default it follows the plan
-        featureAdvancedGraphql: bool | *false
-    }
+	graphql: {
+		// manually enable graphi on a per-service basis
+		// by default it follows the plan
+		featureAdvancedGraphql: bool | *false
+	}
 
 	postgres: {
-		enabled: bool | *true
-        majorVersion: "14"|"15"|"16" | *"14"
+		enabled:      bool | *true
+		majorVersion: "14" | "15" | "16" | *"14"
 		if enabled {
 			database: string
 		}
@@ -607,10 +609,10 @@ import (
 			storage: string
 		}
 
-        disk?: {
-            iops: uint32 | *3000
-            tput: uint32 | *125
-        }
+		disk?: {
+			iops: uint32 | *3000
+			tput: uint32 | *125
+		}
 	}
 }
 
@@ -679,9 +681,9 @@ import (
 	// Number of replicas for a service
 	replicas: uint8 & <=10
 
-    autoscaler?: #Autoscaler
+	autoscaler?: #Autoscaler
 
-    _validateReplicasMustBeSmallerThanMaxReplicas: (replicas <= autoscaler.maxReplicas) & true @cuegraph(skip)
+	_validateReplicasMustBeSmallerThanMaxReplicas: (replicas <= autoscaler.maxReplicas) & true @cuegraph(skip)
 
 	_replcas_cant_be_greater_than_1_when_using_storage: (len(storage) == 0 | (len(storage) > 0 & replicas <= 1 && autoscaler == _|_)) & true @cuegraph(skip)
 
@@ -690,8 +692,8 @@ import (
 
 #RunServiceImage: {
 	image: string
-    // content of "auths", i.e., { "auths": $THIS }
-    pullCredentials?: string
+	// content of "auths", i.e., { "auths": $THIS }
+	pullCredentials?: string
 }
 
 #HealthCheck: {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -541,7 +541,7 @@ github.com/muesli/termenv
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 ## explicit
 github.com/munnerz/goautoneg
-# github.com/nhost/be v0.0.0-20240827074322-bfcccb6fe6f4
+# github.com/nhost/be v0.0.0-20240827125525-b9345d4154be
 ## explicit; go 1.22.4
 github.com/nhost/be/lib/graphql
 github.com/nhost/be/lib/graphql/context


### PR DESCRIPTION
This PR bumps the Nhost Dashboard Docker image to version 1.27.0.