### PR TITLE
fix: set the correct variable

### DIFF
--- a/dockercompose/ai.go
+++ b/dockercompose/ai.go
@@ -13,7 +13,7 @@ func ai(
 		cfg,
 		"http://graphql:8080/v1/graphql",
 		"postgres://postgres@postgres:5432/local?sslmode=disable",
-		"http://storage:5000",
+		"http://storage:5000/v1",
 		"",
 	)
 

--- a/dockercompose/ai_test.go
+++ b/dockercompose/ai_test.go
@@ -22,7 +22,7 @@ func expectedAI() *Service {
 			"GRAPHITE_BASE_URL":           "http://ai:8090",
 			"GRAPHITE_WEBHOOK_SECRET":     "webhookSecret",
 			"HASURA_GRAPHQL_ADMIN_SECRET": "adminSecret",
-			"NHOST_STORAGE_URL":           "http://storage:5000",
+			"NHOST_STORAGE_URL":           "http://storage:5000/v1",
 			"LICENSE":                     "",
 			"NHOST_GRAPHQL_URL":           "http://graphql:8080/v1/graphql",
 			"OPENAI_API_KEY":              "openaiApiKey",


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the `NHOST_STORAGE_URL` in the `ai` function to include the `/v1` path.
- Updated the corresponding test in `ai_test.go` to reflect the corrected `NHOST_STORAGE_URL`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ai.go</strong><dd><code>Corrected NHOST_STORAGE_URL path in ai function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dockercompose/ai.go

- Updated the `NHOST_STORAGE_URL` to include the `/v1` path.



</details>


  </td>
  <td><a href="https://github.com/nhost/cli/pull/930/files#diff-eaefd76d4b099b72d062805dee9d91cf55d1f6c46ff5aaa061d706d1535aa023">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ai_test.go</strong><dd><code>Adjusted test for NHOST_STORAGE_URL path correction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dockercompose/ai_test.go

<li>Updated the <code>NHOST_STORAGE_URL</code> in the expected environment variables to <br>include the <code>/v1</code> path.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/cli/pull/930/files#diff-05e138c4ddc1ca82b2f92ac44b1174fd094c9cd50e515b1879b0ee56825ed612">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information