### PR TITLE
chore: bump nhost/dashboard to 2.10.0

### DIFF
--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -110,7 +110,7 @@ func CommandUp() *cli.Command { //nolint:funlen
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:2.9.0",
+				Value:   "nhost/dashboard:2.10.0",
 				EnvVars: []string{"NHOST_DASHBOARD_VERSION"},
 			},
 			&cli.StringFlag{ //nolint:exhaustruct


### PR DESCRIPTION
### **User description**
This PR bumps the Nhost Dashboard Docker image to version 2.10.0.


___

### **PR Type**
enhancement


___

### **Description**
- Updated the Nhost Dashboard Docker image version in the `cmd/dev/up.go` file from 2.9.0 to 2.10.0.
- This change ensures that the latest features and fixes in version 2.10.0 are utilized.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>up.go</strong><dd><code>Update Nhost Dashboard Docker image version to 2.10.0</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/dev/up.go

<li>Updated the default Nhost Dashboard Docker image version from 2.9.0 to <br>2.10.0.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/cli/pull/931/files#diff-b5263420bb6de52a7fe9a32d559b072b12707f31b6c44ca720c2e93cc15b17e2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information