### PR TITLE
chore: bump nhost/dashboard to 2.15.0

### DIFF
--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -110,7 +110,7 @@ func CommandUp() *cli.Command { //nolint:funlen
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:2.13.0",
+				Value:   "nhost/dashboard:2.15.0",
 				EnvVars: []string{"NHOST_DASHBOARD_VERSION"},
 			},
 			&cli.StringFlag{ //nolint:exhaustruct


### PR DESCRIPTION
This PR bumps the Nhost Dashboard Docker image to version 2.15.0.