### PR TITLE
chore: bump nhost/dashboard to 2.17.0

### DIFF
--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -110,7 +110,7 @@ func CommandUp() *cli.Command { //nolint:funlen
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:2.16.0",
+				Value:   "nhost/dashboard:2.17.0",
 				EnvVars: []string{"NHOST_DASHBOARD_VERSION"},
 			},
 			&cli.StringFlag{ //nolint:exhaustruct


### PR DESCRIPTION
### **User description**
This PR bumps the Nhost Dashboard Docker image to version 2.17.0.


___

### **PR Type**
Enhancement


___

### **Description**
- Update Nhost Dashboard Docker image to version 2.17.0


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>up.go</strong><dd><code>Update Nhost Dashboard version in CLI configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/dev/up.go

- Updated `flagDashboardVersion` default value from 2.16.0 to 2.17.0


</details>


  </td>
  <td><a href="https://github.com/nhost/cli/pull/944/files#diff-b5263420bb6de52a7fe9a32d559b072b12707f31b6c44ca720c2e93cc15b17e2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>