### PR TITLE
chore: bump nhost/dashboard to 2.28.0

### DIFF
--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -110,7 +110,7 @@ func CommandUp() *cli.Command { //nolint:funlen
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
-				Value:   "nhost/dashboard:2.20.0",
+				Value:   "nhost/dashboard:2.28.0",
 				EnvVars: []string{"NHOST_DASHBOARD_VERSION"},
 			},
 			&cli.StringFlag{ //nolint:exhaustruct


### PR DESCRIPTION
This PR bumps the Nhost Dashboard Docker image to version 2.28.0.