### PR TITLE
feat: configurable ports for dashboard and mailhog

### DIFF
--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -39,6 +39,8 @@ const (
 	flagsFunctionsPort     = "functions-port"
 	flagsHasuraPort        = "hasura-port"
 	flagsHasuraConsolePort = "hasura-console-port"
+	flagDashboardPort      = "dashboard-port"
+	flagMailhogPort        = "mailhog-port"
 	flagDashboardVersion   = "dashboard-version"
 	flagConfigserverImage  = "configserver-image"
 	flagRunService         = "run-service"
@@ -107,6 +109,16 @@ func CommandUp() *cli.Command { //nolint:funlen
 				Usage: "If specified, expose hasura console on this port. Not recommended",
 				Value: 0,
 			},
+			&cli.UintFlag{ //nolint:exhaustruct
+				Name:    flagDashboardPort,
+				Usage:   "If specified, expose dashboard on this port. Not recommended",
+				Value:   0,
+			},
+			&cli.UintFlag{ //nolint:exhaustruct
+				Name:    flagMailhogPort,
+				Usage:   "If specified, expose mailhog on this port. Not recommended",
+				Value:   0,
+			},
 			&cli.StringFlag{ //nolint:exhaustruct
 				Name:    flagDashboardVersion,
 				Usage:   "Dashboard version to use",
@@ -174,6 +186,8 @@ func commandUp(cCtx *cli.Context) error {
 			Graphql:   cCtx.Uint(flagsHasuraPort),
 			Console:   cCtx.Uint(flagsHasuraConsolePort),
 			Functions: cCtx.Uint(flagsFunctionsPort),
+			Dashboard: cCtx.Uint(flagDashboardPort),
+			Mailhog:   cCtx.Uint(flagMailhogPort),
 		},
 		cCtx.String(flagDashboardVersion),
 		configserverImage,
@@ -442,10 +456,10 @@ func printInfo(
 		subdomain, "storage", httpPort, useTLS))
 	fmt.Fprintf(w, "- Functions:\t\t%s\n", dockercompose.URL(
 		subdomain, "functions", httpPort, useTLS))
-	fmt.Fprintf(w, "- Dashboard:\t\t%s\n", dockercompose.URL(
-		subdomain, "dashboard", httpPort, useTLS))
-	fmt.Fprintf(w, "- Mailhog:\t\t%s\n", dockercompose.URL(
-		subdomain, "mailhog", httpPort, useTLS))
+		fmt.Fprintf(w, "- Dashboard:\t\t%s\n", dockercompose.URL(
+			subdomain, "dashboard", httpPort, useTLS))
+		fmt.Fprintf(w, "- Mailhog:\t\t%s\n", dockercompose.URL(
+			subdomain, "mailhog", httpPort, useTLS))
 
 	for _, svc := range runServices {
 		for _, port := range svc.Config.GetPorts() {

--- a/dockercompose/compose.go
+++ b/dockercompose/compose.go
@@ -315,6 +315,7 @@ func dashboard(
 	dashboardVersion string,
 	httpPort uint,
 	useTLS bool,
+	port uint,
 ) *Service {
 	return &Service{
 		Image:      dashboardVersion,
@@ -355,7 +356,7 @@ func dashboard(
 				Rewrite: nil,
 			},
 		}.Labels(),
-		Ports:      []Port{},
+		Ports:      ports(port, dashboardPort),
 		Restart:    "",
 		Volumes:    []Volume{},
 		WorkingDir: new(string),
@@ -444,7 +445,7 @@ func functions( //nolint:funlen
 	}
 }
 
-func mailhog(subdomain, volumeName string, useTLS bool) *Service {
+func mailhog(subdomain, volumeName string, useTLS bool, port uint) *Service {
 	return &Service{
 		Image:      "jcalonso/mailhog:v1.0.1",
 		DependsOn:  nil,
@@ -469,7 +470,7 @@ func mailhog(subdomain, volumeName string, useTLS bool) *Service {
 				Rewrite: nil,
 			},
 		}.Labels(),
-		Ports:   nil,
+		Ports:   ports(port, mailhogPort),
 		Restart: "always",
 		Volumes: []Volume{
 			{
@@ -489,6 +490,8 @@ type ExposePorts struct {
 	Graphql   uint
 	Console   uint
 	Functions uint
+	Dashboard uint
+	Mailhog   uint
 }
 
 func sanitizeBranch(name string) string {
@@ -557,11 +560,11 @@ func getServices( //nolint: funlen,cyclop
 	}
 
 	mailhogVolumeName := "mailhog_" + sanitizeBranch(branch)
-	mailhog := mailhog(subdomain, mailhogVolumeName, useTLS)
+	mailhog := mailhog(subdomain, mailhogVolumeName, useTLS, ports.Mailhog)
 
 	services := map[string]*Service{
 		"console":   console,
-		"dashboard": dashboard(cfg, subdomain, dashboardVersion, httpPort, useTLS),
+		"dashboard": dashboard(cfg, subdomain, dashboardVersion, httpPort, useTLS, ports.Dashboard),
 		"graphql":   graphql,
 		"minio":     minio,
 		"postgres":  postgres,


### PR DESCRIPTION
## Description
<!--
Use one of the following title prefix to categorize the pull request:
feat:   mark this pull request as a feature
fix:    mark this pull request as a bug fix
chore:  mark this pull request as a maintenance item

To auto merge this pull request when it was approved
by another member of the organization: set the label `auto-merge`
-->
feat: configurable ports for Dashboard and Mailhog services

## Problem
The Nhost CLI supports custom ports for most services such as Hasura, Auth, and Postgres, but the ports for the Dashboard and Mailhog services are currently hardcoded. This limits the ability of developers to avoid port conflicts or customize their local environment, particularly when running multiple Nhost instances simultaneously.

## Solution
This PR adds two new CLI flags and associated support throughout the codebase to allow customization of Dashboard and Mailhog ports:
- `--dashboard-port` with env fallback `NHOST_DASHBOARD_PORT`
- `--mailhog-port` with env fallback `NHOST_MAILHOG_PORT`

Key implementation updates:
- Introduced new `UintFlag` definitions for both ports in `cmd/dev/up.go`.
- Extended the `ExposePorts` struct to include `Dashboard` and `Mailhog` fields.
- Updated service creation functions (`dashboard`, `mailhog`) to accept the new ports and apply them using the `ports()` utility.
- Adjusted `getServices()` to pass the port values correctly to each respective service.
- Ensured `printInfo()` remains consistent and informative with the correct URLs displayed (though it still prints the base HTTP port for Dashboard and Mailhog to preserve the current behavior; further enhancements to output format could be addressed in a future PR).

## Notes
- Default behavior remains unchanged if the new flags are not specified.
- This brings Dashboard and Mailhog in line with other services for port configurability.
- Enables better local dev experience with multiple environments or custom tooling.

Example usage:
```bash
nhost up \
  --dashboard-port 3001 \
  --mailhog-port 8026

Closes #967