### PR TITLE
feat: added support for non-unix docker endpoints

### DIFF
--- a/examples/myproject/nhost/nhost.toml
+++ b/examples/myproject/nhost/nhost.toml
@@ -24,7 +24,7 @@ liveQueriesMultiplexedRefetchInterval = 3000
 version = 22
 
 [auth]
-version = '0.37.1'
+version = '0.40.0'
 
 [auth.redirections]
 clientUrl = 'http://localhost:3000'


### PR DESCRIPTION
### **User description**
Fixes #970


___

### **PR Type**
Enhancement


___

### **Description**
- Added support for non-unix Docker endpoints in `DOCKER_HOST`

- Refactored Docker host parsing to accept multiple schemes

- Dynamically set Traefik Docker provider endpoint based on scheme

- Updated example `nhost.toml` to newer auth version


___

### **Changes diagram**

```mermaid
flowchart LR
  A["getDockerHost() now returns *url.URL"] -- "Supports unix & tcp" --> B["traefik() uses dockerURL"]
  B -- "Sets endpoint & volumes dynamically" --> C["Traefik service config"]
  D["examples/myproject/nhost.toml"] -- "Bump auth version" --> E["auth.version = '0.40.0'"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compose.go</strong><dd><code>Add support for tcp and other Docker host schemes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dockercompose/compose.go

<li>Refactored <code>getDockerHost()</code> to return a <code>*url.URL</code> and support non-unix <br>schemes<br> <li> Updated Traefik service to dynamically set Docker endpoint and volumes<br> <li> Removed restriction on only unix scheme for Docker host<br> <li> Improved error handling and configuration flexibility


</details>


  </td>
  <td><a href="https://github.com/nhost/cli/pull/971/files#diff-67d473eea1a53a8257f907983067eaabe35308b83d3a28d7f7705e7dfa396c40">+28/-26</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nhost.toml</strong><dd><code>Bump auth version in example configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/myproject/nhost/nhost.toml

- Updated `auth.version` from '0.37.1' to '0.40.0'


</details>


  </td>
  <td><a href="https://github.com/nhost/cli/pull/971/files#diff-ce9635d2304c2ca0ee06fd0e9d02f1b18238aa11c98c49aec9f58821031f1c44">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>