### PR TITLE
fix: use resolved object when constructing cloud configuration

### DIFF
--- a/cmd/dev/cloud.go
+++ b/cmd/dev/cloud.go
@@ -176,13 +176,13 @@ func cloud( //nolint:funlen
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, 5*time.Second) //nolint:mnd
 	defer cancel()
 	ce.Infoln("Checking versions...")
-	if err := software.CheckVersions(ctxWithTimeout, ce, cfg, appVersion); err != nil {
+	if err := software.CheckVersions(ctxWithTimeout, ce, cfgSecrets, appVersion); err != nil {
 		ce.Warnln("Problem verifying recommended versions: %s", err.Error())
 	}
 
 	ce.Infoln("Setting up Nhost development environment...")
 	composeFile, err := dockercompose.CloudComposeFileFromConfig(
-		cfg,
+		cfgSecrets,
 		ce.LocalSubdomain(),
 		proj.GetSubdomain(),
 		proj.GetRegion().GetName(),
@@ -231,7 +231,7 @@ func cloud( //nolint:funlen
 		ctx,
 		ce.LocalSubdomain(),
 		ce.Path.NhostFolder(),
-		*cfg.Hasura.Version,
+		*cfgSecrets.Hasura.Version,
 		"metadata", "export",
 		"--skip-update-check",
 		"--log-level", "ERROR",


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixes use of resolved config object in cloud setup functions

- Ensures secrets-resolved config is used for version checks and compose file

- Updates `ValidateRemote` to apply JSON patches before secrets resolution

- Improves documentation for `ValidateRemote` function


___

### **Changes diagram**

```mermaid
flowchart LR
  A["ValidateRemote applies JSON patches first"]
  B["SecretsResolver called with patched config"]
  C["cloud() uses cfgSecrets for checks and compose"]
  D["Improved ValidateRemote documentation"]

  A -- "patched config" --> B
  B -- "returns cfgSecrets" --> C
  B -- "returns cfgSecrets" --> D
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate.go</strong><dd><code>Refactor and document ValidateRemote, fix patch/secrets order</code></dd></summary>
<hr>

cmd/config/validate.go

<li>Calls <code>SecretsResolver</code> without type parameter for consistency<br> <li> Applies JSON patches before secrets resolution in <code>ValidateRemote</code><br> <li> Adds detailed documentation for <code>ValidateRemote</code><br> <li> Removes duplicate JSON patch application logic


</details>


  </td>
  <td><a href="https://github.com/nhost/cli/pull/974/files#diff-805522e85a1b897c74ea4538bf6e4f3572378babef96fe97240d5acfe5c10e46">+16/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cloud.go</strong><dd><code>Use secrets-resolved config for cloud environment setup</code>&nbsp; &nbsp; </dd></summary>
<hr>

cmd/dev/cloud.go

<li>Uses secrets-resolved config (<code>cfgSecrets</code>) for version checks<br> <li> Passes <code>cfgSecrets</code> to compose file and Hasura wrapper<br> <li> Ensures cloud setup uses fully resolved configuration


</details>


  </td>
  <td><a href="https://github.com/nhost/cli/pull/974/files#diff-c667a7d1c05d4880f25ea4fa1cf4e77f419cc0adaed8fdbc6f1a15f5f1d27cf2">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>