### PR TITLE
fix(ci): install/upgrade cli from nhost/nhost version

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,13 +1,23 @@
 version: "2"
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 linters:
   default: all
+  settings:
+    funlen:
+      lines: 65
   disable:
+    - canonicalheader
     - depguard
     - gomoddirectives
+    - musttag
     - nlreturn
+    - tagliatelle
     - varnamelen
     - wsl
     - noinlineerr
+    - funcorder
   exclusions:
     generated: lax
     presets:
@@ -26,13 +36,16 @@ linters:
       - linters:
           - gochecknoglobals
         text: Version is a global variable
+      - linters:
+          - ireturn
+          - lll
+        path: schema\.resolvers\.go
     paths:
       - third_party$
       - builtin$
       - examples$
 formatters:
   enable:
-    - gci
     - gofmt
     - gofumpt
     - goimports
@@ -42,3 +55,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+      - schema\.resolvers\.go

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+NOTE: This repository is deprecated. All development has moved to https://github.com/nhost/nhost
+
 <div align="center">
   <h1 style="font-size: 3em; font-weight: bold;">Nhost CLI</h1>
 </div>

--- a/cmd/software/upgrade.go
+++ b/cmd/software/upgrade.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/nhost/cli/clienv"
 	"github.com/nhost/cli/software"
@@ -42,7 +43,14 @@ func commandUpgrade(cCtx *cli.Context) error {
 
 	ce.Infoln("Upgrading to %s...", latest.TagName)
 
-	want := fmt.Sprintf("cli-%s-%s-%s.tar.gz", latest.TagName, runtime.GOOS, runtime.GOARCH)
+	version := latest.TagName
+	s := strings.Split(latest.TagName, "@")
+
+	if len(s) == 2 { //nolint:mnd
+		version = s[1]
+	}
+
+	want := fmt.Sprintf("cli-%s-%s-%s.tar.gz", version, runtime.GOOS, runtime.GOARCH)
 
 	var url string
 

--- a/dockercompose/compose.go
+++ b/dockercompose/compose.go
@@ -637,7 +637,7 @@ func mountCACertificates(
 	}
 }
 
-func ComposeFileFromConfig( //nolint:funlen
+func ComposeFileFromConfig(
 	cfg *model.ConfigConfig,
 	subdomain string,
 	projectName string,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update upgrade command to parse `cli@` tags

- Introduce `filterReleases` to exclude old/prereleases

- Switch GitHub API paths to use `nhost/nhost` repo

- Enhance `get.sh` for version retrieval and URL encoding


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upgrade.go</strong><dd><code>Version parsing in upgrade command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/software/upgrade.go

<ul><li>Imported <code>strings</code> package<br> <li> Split <code>latest.TagName</code> on <code>@</code> to extract version<br> <li> Constructed download filename with parsed version</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/cli/pull/985/files#diff-15cd41384152c43ee1ed06489b93d137a74fdce85ac7ec75efa9113b57c178af">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sofware.go</strong><dd><code>Release filtering and API path update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

software/sofware.go

<ul><li>Added <code>filterReleases</code> method for version filtering<br> <li> Updated <code>GetReleases</code> to call <code>filterReleases</code><br> <li> Switched API URL to <code>https://api.github.com/repos/nhost/nhost/releases</code><br> <li> Imported <code>strings</code> package</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/cli/pull/985/files#diff-2880a796f9eea1e57c9f864851aa8d10e90d4e9ecb8d5e20175621680cf4ec56">+35/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>get.sh</strong><dd><code>Install script repo and URL encoding update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

get.sh

<ul><li>Changed <code>REPO</code> to <code>nhost/nhost</code><br> <li> Retrieved latest <code>cli@</code> tag from GitHub releases<br> <li> Encoded <code>@</code> as <code>%40</code> in download URL</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/cli/pull/985/files#diff-050ee235c1f102f985451ea7bbbdc20b8f78d1acb9f7476457318427490588de">+11/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

